### PR TITLE
Add AWS Documentation MCP server integration

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -2,6 +2,7 @@
 .clinerules
 .github/workflows/pull_request_template.md
 .markdownlint-cli2.jsonc
+.mcp.json
 .mise.local.toml
 .memo.local.md
 .obsidian

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -33,4 +33,5 @@ ln -sf ${DOTFILES_PATH}/.github/workflows/pull_request_template.md .github/workf
 ln -sf ${DOTFILES_PATH}/.clinerules .clinerules
 ln -sf ${DOTFILES_PATH}/.pre-commit-config.yaml .pre-commit-config.yaml
 ln -sf ${DOTFILES_PATH}/.markdownlint-cli2.jsonc .markdownlint-cli2.jsonc
+ln -sf ${DOTFILES_PATH}/.mcp.json .mcp.json
 """

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "aws-docs": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "awslabs.aws-documentation-mcp-server@latest"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MacOS用の初期セットアップを行います。
 ├── .zprofile                         # Zsh環境変数など
 ├── .vimrc                            # Vim設定
 ├── .gitconfig                        # Git設定
+├── .mcp.json                         # MCPサーバー設定（プロジェクトスコープ）
 ├── .claude/                          # Claude Code設定
 │   ├── CLAUDE.md                     # グローバル指示
 │   ├── settings.json                 # グローバル設定（現在未使用）
@@ -120,6 +121,7 @@ mise run setup-links
 - .clinerules/
 - .pre-commit-config.yaml
 - .markdownlint-cli2.jsonc
+- .mcp.json
 
 ## 開発コマンド
 
@@ -164,6 +166,55 @@ Claude Codeの設定ファイルは現在、他の設定ファイルとは異な
 - グローバル指示: `~/.claude/CLAUDE.md` （シンボリックリンクで管理）
 - グローバル設定: `~/.claude.json` （Claude Code内部管理のためシンボリックリンク不可）
 - カスタムコマンド: `~/.claude/commands/` （シンボリックリンクで管理）
+
+### MCP（Model Context Protocol）サーバー
+
+Claude CodeはMCPサーバーを使って外部ツールやサービスと連携できます。現在以下のMCPサーバーが設定されています：
+
+- **AWS Documentation MCP Server**: AWSドキュメントへのアクセスを提供
+  - コマンド: `uvx awslabs.aws-documentation-mcp-server@latest`
+  - スコープ: ユーザー（全プロジェクトで利用可能）
+  - 機能: AWS認証不要でドキュメントの閲覧・検索が可能
+
+#### MCPサーバー設定ファイル
+
+MCPサーバーの設定は `~/.claude.json` ファイルの `mcpServers` セクションに保存されます：
+
+```json
+{
+  "mcpServers": {
+    "aws-docs": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}
+```
+
+**注意事項**:
+
+- `~/.claude.json` はClaude Code内部で管理されるファイルのため、シンボリックリンクでの管理は推奨されません
+- プロジェクト固有のMCPサーバーは、プロジェクトルートの `.mcp.json` ファイルで設定可能
+
+#### MCP設定の管理コマンド
+
+```bash
+# MCP サーバーの一覧表示
+claude mcp list
+
+# MCP サーバーの詳細確認
+claude mcp get <server-name>
+
+# MCP サーバーの追加（例）
+claude mcp add <name> uvx <package-name> -s user -e ENV_VAR=value
+
+# MCP サーバーの削除
+claude mcp remove <name> -s user
+```
 
 ### カスタムコマンド
 


### PR DESCRIPTION
## 変更の概要

AWS Documentation MCP Serverの統合設定を追加しました。これによりClaude CodeからAWSドキュメントへの直接アクセスが可能になります。

Fixed: #5 

## 主な変更点

- .mcp.jsonファイルを作成してAWS Documentation MCP Serverを設定
- setup-linksタスクに.mcp.jsonのシンボリックリンク作成を追加
- .config/git/ignoreに.mcp.jsonを追加してaccidental commitを防止
- README.mdにMCP設定の詳細なドキュメントを追加
- ディレクトリ構造図を更新して.mcp.jsonを含める

## 他、軽微な修正

- MCPサーバー設定の管理コマンド例をREADMEに追加
- FASTMCP_LOG_LEVEL環境変数の設定を最適化

## 変更の背景

issue #5で要求されたAWS Document MCPの連携設定を実現するため、以下の課題を解決しました：
- Claude CodeでAWSドキュメントに効率的にアクセスしたい
- 設定をバージョン管理して他のプロジェクトでも再利用したい
- 個人用途のため、グローバル設定とプロジェクト設定を使い分けたい

## 補足

MCPサーバーはユーザースコープ（~/.claude.json）とプロジェクトスコープ（.mcp.json）の両方で設定済みです。AWS認証は不要で、ドキュメントの閲覧・検索のみ対応しています。