### PR TITLE
Optimize scan-brew performance by batching brew info calls

### DIFF
--- a/.config/mise/tasks/scan-brew
+++ b/.config/mise/tasks/scan-brew
@@ -63,7 +63,6 @@ with open(brewfile_path) as bf:
         elif line.startswith('cask \"'):
             bf_casks.append(line.split('\"')[1])
 
-bf_formulae_set = set(bf_formulae)
 bf_formulae_short_set = {name.rsplit('/', 1)[-1] for name in bf_formulae}
 bf_casks_set = set(bf_casks)
 
@@ -95,11 +94,15 @@ except json.JSONDecodeError as exc:
 # Fetch info for missing casks (in Brewfile but not installed)
 missing_casks = sorted(bf_casks_set - installed_casks_set)
 if missing_casks:
-    result = subprocess.run(
-        ['brew', 'info', '--json=v2', '--cask'] + missing_casks,
-        capture_output=True, text=True,
-    )
-    if result.returncode == 0 and result.stdout.strip():
+    try:
+        result = subprocess.run(
+            ['brew', 'info', '--json=v2', '--cask'] + missing_casks,
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        print('Warning: brew info --cask timed out', file=sys.stderr)
+        result = None
+    if result is not None and result.returncode == 0 and result.stdout.strip():
         try:
             mdata = json.loads(result.stdout)
             for cask in mdata.get('casks', []):
@@ -109,7 +112,7 @@ if missing_casks:
                     pkg_auto[token] = 'auto_updates'
         except json.JSONDecodeError as exc:
             print(f'Warning: Failed to parse missing cask info: {exc}', file=sys.stderr)
-    elif result.returncode != 0:
+    elif result is not None and result.returncode != 0:
         print(f'Warning: brew info --cask failed (exit {result.returncode})', file=sys.stderr)
 
 # === Installed but not in Brewfile ===


### PR DESCRIPTION
## 変更の概要

scan-brewタスクのパフォーマンスを改善しました。`brew info` の呼び出しをパッケージごとの個別実行から一括取得に変更し、差分計算ロジックをPythonに移行しました。

## 主な変更点

- `brew info --json=v2 --installed` で全パッケージ情報を1回で取得（旧: パッケージごとに個別呼び出し）
- 未インストールcaskの情報も `brew info --json=v2 --cask` で一括取得
- 差分計算・出力ロジックをPythonに移行し、`dict`/`set` によるO(1)ルックアップを実現
- `get_pkg_info`（python3内でsubprocessを起動）、`in_array`（線形検索）、`print_section_header` 関数を削除

## 他、軽微な修正

- なし

## 変更の背景

- 旧実装では差分パッケージ1つにつき python3 起動 + `brew info` 実行が発生し、差分が多いほど実行時間が線形に増加していた
- `brew info` は1回あたり3-10秒かかるため、差分15パッケージで45-150秒かかる場合があった
- 改善後は brew コマンド呼び出しが3-4回（固定）となり、パッケージ数に依存しない

## 補足

- macOS標準の bash 3.2 では `declare -A`（連想配列）が使えないため、bashでの連想配列方式は不採用としPythonに差分計算を移行した
- 出力フォーマットは変更前と完全互換

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Brew パッケージスキャン処理を刷新し、スキャン結果の生成をより決定的で信頼できるものにしました。一時ファイルの確実なクリーンアップと詳細なエラーメッセージを追加しています。
* **Bug Fixes**
  * Brewfile と実際のインストール状況の差分検出を改善し、インストール済みだが未登録、登録済みだが未インストールの一覧出力精度を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->