### PR TITLE
プラグインマーケットプレイスの更新検知と一括更新タスクを追加

### DIFF
--- a/.claude/hooks/check-plugin-updates.sh
+++ b/.claude/hooks/check-plugin-updates.sh
@@ -15,8 +15,9 @@ MARKETPLACES_DIR="${HOME}/.claude/plugins/marketplaces"
 behind_lines=()
 
 for mp in "$MARKETPLACES_DIR"/*/; do
-    [[ -d "${mp}.git" ]] || continue
-
+    # `rev-parse @{u}` naturally fails for non-git dirs and for git dirs without
+    # an upstream — so it doubles as our "is this a git marketplace?" filter
+    # while also handling gitfile-based repos (worktrees, submodules) correctly.
     git -C "$mp" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 || continue
 
     behind=$(git -C "$mp" rev-list HEAD..'@{u}' --count 2>/dev/null || echo 0)

--- a/.claude/hooks/check-plugin-updates.sh
+++ b/.claude/hooks/check-plugin-updates.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Surface outdated plugin marketplaces on session start.
+# anthropics/claude-code#41885: session-start auto-sync only does `git fetch`,
+# and DISABLE_AUTOUPDATER=1 in this repo turns even that off, so installed
+# plugins go stale silently. This hook compares HEAD to the locally-known
+# upstream ref (no network in foreground) and fires a detached `git fetch` so
+# the next session has fresh state. Result: at most a 1-session lag on detection,
+# but zero startup latency.
+# Skips non-git marketplaces (e.g. claude-plugins-official uses a GCS snapshot).
+set -euo pipefail
+
+MARKETPLACES_DIR="${HOME}/.claude/plugins/marketplaces"
+[[ -d "$MARKETPLACES_DIR" ]] || exit 0
+
+behind_lines=()
+
+for mp in "$MARKETPLACES_DIR"/*/; do
+    [[ -d "${mp}.git" ]] || continue
+
+    git -C "$mp" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 || continue
+
+    behind=$(git -C "$mp" rev-list HEAD..'@{u}' --count 2>/dev/null || echo 0)
+    if [[ "${behind:-0}" -gt 0 ]]; then
+        name=$(basename "$mp")
+        behind_lines+=("  - ${name} is ${behind} commits behind upstream")
+    fi
+
+    # Detached subshell so the hook returns immediately even if fetch is slow.
+    ( git -C "$mp" fetch --quiet --no-tags >/dev/null 2>&1 & )
+done
+
+[[ ${#behind_lines[@]} -gt 0 ]] || exit 0
+
+printf '[plugin-update] Outdated plugin marketplaces detected:\n'
+for line in "${behind_lines[@]}"; do
+    printf '%s\n' "$line"
+done
+printf '  Run: mise run upgrade-plugins\n'

--- a/.claude/hooks/check-plugin-updates.sh
+++ b/.claude/hooks/check-plugin-updates.sh
@@ -25,8 +25,9 @@ for mp in "$MARKETPLACES_DIR"/*/; do
         behind_lines+=("  - ${name} is ${behind} commits behind upstream")
     fi
 
-    # Detached subshell so the hook returns immediately even if fetch is slow.
-    ( git -C "$mp" fetch --quiet --no-tags >/dev/null 2>&1 & )
+    # nohup detaches from the hook's process group so the fetch survives even
+    # if Claude Code SIGHUPs the hook on exit.
+    nohup git -C "$mp" fetch --quiet --no-tags >/dev/null 2>&1 &
 done
 
 [[ ${#behind_lines[@]} -gt 0 ]] || exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,17 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /Users/rysk/Repositories/rysk/dotfiles/.claude/hooks/check-plugin-updates.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.config/mise/tasks/upgrade-plugins
+++ b/.config/mise/tasks/upgrade-plugins
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#MISE description="Update all Claude Code plugin marketplaces and show version changes"
+
+set -euo pipefail
+
+if ! command -v claude &>/dev/null; then
+    echo "Error: claude (Claude Code CLI) is not installed" >&2
+    exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 is not installed" >&2
+    exit 1
+fi
+
+TMPDIR_PATH=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_PATH"' EXIT
+
+before_file="${TMPDIR_PATH}/before.json"
+after_file="${TMPDIR_PATH}/after.json"
+
+# Session-start auto-sync only does `git fetch` (anthropics/claude-code#41885),
+# but explicit `marketplace update` performs `git pull` and bumps installed plugins.
+claude plugin list --json > "$before_file"
+claude plugin marketplace update
+claude plugin list --json > "$after_file"
+
+python3 - "$before_file" "$after_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    before = {p["id"]: p["version"] for p in json.load(f)}
+with open(sys.argv[2]) as f:
+    after = {p["id"]: p["version"] for p in json.load(f)}
+
+changes = []
+for plugin_id in sorted(before.keys() | after.keys()):
+    bv = before.get(plugin_id, "(new)")
+    av = after.get(plugin_id, "(removed)")
+    if bv != av:
+        changes.append(f"  {plugin_id}: {bv} -> {av}")
+
+print()
+if changes:
+    print("Plugin version changes:")
+    for line in changes:
+        print(line)
+    print()
+    print("Restart Claude Code or run /reload-plugins to apply.")
+else:
+    print("All plugins are up to date.")
+PY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Suggest branch name: `mise run suggest-branch` (analyzes work and suggests branch names)
 - Setup skills symlinks: `mise run setup-skills` (clones `rysk-tanaka/skills` if missing and creates per-skill symlinks under `.claude/skills/`). dotfiles 初回 clone 直後に必須。未実行だと `/auto-commit` `/pr` `/resolve-review` 等の参照先 script が無く失敗する
 - Upgrade Claude Code: `mise run upgrade-claude` (upgrades to latest GitHub Release, bypassing aqua registry lag)
+- Update Claude Code plugins: `mise run upgrade-plugins` (runs `claude plugin marketplace update` to force `git pull` and reports version diff; works around session-start auto-sync only doing `git fetch` per anthropics/claude-code#41885)
 
 Note: Python files are auto-linted via PostToolUse hook after Edit/Write. Manual lint is only needed for final verification.
 
@@ -95,6 +96,7 @@ Symlinks are tracked in `~/.config/mise/linked-repos/` for bulk management.
 
 Located in `.claude/hooks/`, configured in `.claude/settings.json` under `hooks`.
 
+- SessionStart (`check-plugin-updates.sh`) - Detects outdated plugin marketplaces by comparing HEAD to local upstream ref, then fires a detached `git fetch` so the next session has fresh state. Needed because session-start auto-sync is broken (anthropics/claude-code#41885) and `DISABLE_AUTOUPDATER=1` turns it off entirely. 1-session lag on first detection, zero startup latency. Skips non-git marketplaces (e.g. `claude-plugins-official` uses GCS).
 - UserPromptSubmit (`suggest-effort.sh`) - Analyzes prompt complexity via keyword scoring and suggests effort level adjustments. Outputs plain text to stdout (not JSON, to avoid claude-code#17550). Must complete in < 100ms.
 - PostToolUse - Auto-lints Python files after Edit/Write (inline command in settings.json)
 - Stop - cmux claude-hook でセッション完了を通知（cmux 以外のターミナルでは静かにスキップ）


### PR DESCRIPTION
## 変更の概要

Claude Code プラグインのマーケットプレイスが古いままになる問題に対し、起動時の検知フックと一括更新用 mise タスクを追加します。

## 主な変更点

- `mise run upgrade-plugins` タスクを追加します。`claude plugin marketplace update` で全マーケットプレイスを `git pull` し、バージョン差分を表示します。
- SessionStart フック (`check-plugin-updates.sh`) を追加します。各マーケットプレイスの HEAD と upstream を比較し、遅れがあれば 1 行で通知します。
- フックは前景で `git fetch` を行わず、非同期でバックグラウンド fetch を起動するため起動レイテンシはゼロです。
- CLAUDE.md の Commands / Hooks セクションに追加機能を記載します。

## 変更の背景

claude-code 本体のセッション起動時 auto-sync は `git fetch` のみで `git pull` を行わない既知の不具合があります。
さらに本リポジトリでは `DISABLE_AUTOUPDATER=1` により auto-sync 自体が無効化されているため、サードパーティ製プラグイン (codex, wakatime 等) が静かに古くなる状況でした。

## 補足

- 検知フックは初回起動時のみ silent (前回 fetch のキャッシュが無いため)、2 回目以降から behind を検出します。
- 公式マーケットプレイス (`claude-plugins-official`) は GCS スナップショット方式で git 管理ではないため検知対象外です。
- 動作確認済みで、本セッションの起動時に `wakatime is 1 commits behind upstream` を検知しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セッション開始時にローカルプラグインの更新有無を自動検出して通知（更新がある場合のみ案内）。
  * 新しいコマンドでプラグインを一括更新し、更新前後のバージョン差分を表示。

* **ドキュメント**
  * プラグイン更新検出の動作と一括更新コマンドの利用手順を追記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rysk-tanaka/dotfiles/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->