### PR TITLE
sync-tools で gh credential helper を自動正規化

### DIFF
--- a/.config/mise/tasks/sync-tools
+++ b/.config/mise/tasks/sync-tools
@@ -34,7 +34,23 @@ else
     fi
 fi
 
-# 3. Codex health checks (best-effort, non-fatal)
+# 3. normalize gh credential helper (version-pinned path → PATH-resolved)
+# gh auth setup-git は gh の絶対パス（バージョン固定）を helper に焼き込むため、
+# 上の prune で旧バージョンが消えると helper が壊れる。PATH 解決形に書き換えて再発を防ぐ。
+echo ""
+echo "==> Normalizing gh credential helpers..."
+broken_keys=$(git config --global --get-regexp 'credential\..*\.helper' \
+    | awk '/aqua-cli-cli\/[0-9]/ {print $1}' | sort -u)
+if [ -z "$broken_keys" ]; then
+    echo "  ✓ no version-pinned paths"
+else
+    while IFS= read -r key; do
+        git config --global --replace-all "$key" '!gh auth git-credential' 'aqua-cli-cli/[0-9]'
+        echo "  fixed: $key"
+    done <<< "$broken_keys"
+fi
+
+# 4. Codex health checks (best-effort, non-fatal)
 echo ""
 echo "==> Codex health:"
 if ! command -v codex &>/dev/null; then
@@ -42,7 +58,7 @@ if ! command -v codex &>/dev/null; then
     exit 0
 fi
 
-# 3a. CLI version lag (brew のキャッシュ状態を参照)
+# 4a. CLI version lag (brew のキャッシュ状態を参照)
 if command -v brew &>/dev/null; then
     if brew outdated --cask codex 2>/dev/null | grep -q '^codex'; then
         echo "  ⚠ codex is outdated — run: brew upgrade --cask codex"
@@ -53,7 +69,7 @@ else
     echo "  - version check skipped (brew not available)"
 fi
 
-# 3b. configured model がカタログに在るか（撤去検知）
+# 4b. configured model がカタログに在るか（撤去検知）
 # config.toml を tomllib でパースして top-level model を取得（Python 3.11+ stdlib、引用符の差異を正しく処理）
 conf_model=$(python3 -c "import tomllib,sys; print(tomllib.load(open(sys.argv[1],'rb')).get('model',''))" "${DOTFILES_PATH}/.codex/config.toml" 2>/dev/null || true)
 if [ -z "$conf_model" ]; then

--- a/.config/mise/tasks/sync-tools
+++ b/.config/mise/tasks/sync-tools
@@ -39,8 +39,8 @@ fi
 # 上の prune で旧バージョンが消えると helper が壊れる。PATH 解決形に書き換えて再発を防ぐ。
 echo ""
 echo "==> Normalizing gh credential helpers..."
-broken_keys=$(git config --global --get-regexp 'credential\..*\.helper' \
-    | awk '/aqua-cli-cli\/[0-9]/ {print $1}' | sort -u)
+broken_keys=$(git config --global --get-regexp 'credential\..*\.helper' 2>/dev/null \
+    | awk '/aqua-cli-cli\/[0-9]/ {print $1}' | sort -u || true)
 if [ -z "$broken_keys" ]; then
     echo "  ✓ no version-pinned paths"
 else


### PR DESCRIPTION
## 変更の概要

`mise run sync-tools` の prune 直後に、gh の credential helper を正規化するステップを追加しました。

## 主な変更点

- バージョン固定された aqua の gh 絶対パスを含む helper を `!gh auth git-credential`（PATH 解決形）へ置換する処理を追加しました。
- `gh auth setup-git` が生成する空のリセット行は保持したまま、壊れた値のみを置換します。
- 既存の Codex health checks セクションのステップ番号を 3 から 4 へ繰り下げました。

## 変更の背景

`gh auth setup-git` は credential helper に gh のバージョン固定絶対パスを焼き込みます。
mise/aqua が gh を upgrade して旧バージョンを prune すると、このパスが消えて helper が壊れ、git 認証が `No such file or directory` で失敗します。
prune を実行する sync-tools 自身に正規化を組み込むことで、破損と修復の契機を一致させ再発を防ぎます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 開発ツールの信頼性を向上しました。認証情報の扱いを正規化して、環境変化で発生する処理の破綻を防ぎます。
  * 内部の処理順序とチェックを整理し、外部モジュール未導入時のスキップ動作を維持しつつ、設定で指定したモデルがカタログに存在するかの検知を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->