### PR TITLE
auto-commit/suggest-branch に Apple Intelligence (rintel) バックエンドを追加

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -44,7 +44,9 @@ zoxide = "0.9.9"
 
 # github: tools
 "github:rysk-tanaka/csvr" = "0.2.0"
-"github:rysk-tanaka/rintel" = "0.2.0"     # Apple Intelligence backend for auto-commit/suggest-branch; arm64 macOS only
+# Apple Intelligence backend for auto-commit/suggest-branch; release ships arm64 macOS only,
+# so gate with os to keep `mise install` working on Intel macOS / Linux clones
+"github:rysk-tanaka/rintel" = { version = "0.2.0", os = ["macos/arm64"] }
 
 # npm: tools
 "npm:aws-cdk" = "2.1107.0"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -44,6 +44,7 @@ zoxide = "0.9.9"
 
 # github: tools
 "github:rysk-tanaka/csvr" = "0.2.0"
+"github:rysk-tanaka/rintel" = "0.2.0"     # Apple Intelligence backend for auto-commit/suggest-branch; arm64 macOS only
 
 # npm: tools
 "npm:aws-cdk" = "2.1107.0"

--- a/.config/mise/tasks/auto-commit
+++ b/.config/mise/tasks/auto-commit
@@ -41,7 +41,7 @@ if [[ "$USE_CODEX" == "true" ]]; then
     SKILL_PATH="${DOTFILES}/.codex/skills/auto-commit/SKILL.md"
 elif [[ "$USE_RINTEL" == "true" ]]; then
     if ! command -v rintel &>/dev/null; then
-        echo "Error: rintel command not found. Run 'mise install' to install it." >&2
+        echo "Error: rintel command not found. rintel is mise-managed on macOS arm64 only; on a supported host run 'mise install'." >&2
         exit 1
     fi
     SKILL_PATH="${DOTFILES}/.claude/skills/auto-commit/SKILL.md"
@@ -104,17 +104,15 @@ elif [[ "$USE_RINTEL" == "true" ]]; then
     # output to the schema and eliminates the small model's invalid-JSON failures
     # (value-level example-parroting is handled separately below by stripping the
     # example block). The downstream fence-strip + jq parse still runs as a
-    # backend-agnostic safety net. The language guardrail rejects Japanese prose
-    # mixed with <git-data> XML tags, so use a plain delimiter. rintel rejects
-    # --system values starting with '-' (the frontmatter '---'), so pass it via
-    # the --system= form; '--' then terminates options before the positional prompt.
-    RINTEL_PROMPT="以下の git データを分析してコミットメッセージ候補を生成してください。
-
-git データ:
-${GIT_DATA}"
+    # backend-agnostic safety net. Git data is passed via --file (a temp file),
+    # not embedded in argv, so large diffs don't hit ARG_MAX and the diff isn't
+    # exposed in the process list. rintel rejects --system values starting with
+    # '-' (the frontmatter '---'), so pass it via the --system= form.
     SCHEMA_FILE=$(mktemp)
+    GITDATA_FILE=$(mktemp)
     ERRFILE=$(mktemp)
-    trap 'rm -f "$SCHEMA_FILE" "$ERRFILE"' EXIT
+    trap 'rm -f "$SCHEMA_FILE" "$GITDATA_FILE" "$ERRFILE"' EXIT
+    printf '%s' "$GIT_DATA" > "$GITDATA_FILE"
     cat > "$SCHEMA_FILE" <<'SCHEMA'
 {
   "type": "object",
@@ -146,7 +144,8 @@ SCHEMA
         if RESULT=$("$TIMEOUT_CMD" -k 5 30 rintel ask \
             --system="$RINTEL_SYSTEM" \
             --schema="$SCHEMA_FILE" \
-            -- "$RINTEL_PROMPT" 2>"$ERRFILE"); then
+            -f "$GITDATA_FILE" \
+            -- "添付ファイルの git データを分析してコミットメッセージ候補を生成してください。" 2>"$ERRFILE"); then
             RINTEL_OK=true
             break
         fi

--- a/.config/mise/tasks/auto-commit
+++ b/.config/mise/tasks/auto-commit
@@ -41,7 +41,7 @@ if [[ "$USE_CODEX" == "true" ]]; then
     SKILL_PATH="${DOTFILES}/.codex/skills/auto-commit/SKILL.md"
 elif [[ "$USE_RINTEL" == "true" ]]; then
     if ! command -v rintel &>/dev/null; then
-        echo "Error: rintel command not found. Build & install it from the rintel repo: cargo install --path apps/cli" >&2
+        echo "Error: rintel command not found. Run 'mise install' to install it." >&2
         exit 1
     fi
     SKILL_PATH="${DOTFILES}/.claude/skills/auto-commit/SKILL.md"
@@ -100,12 +100,14 @@ if [[ "$USE_CODEX" == "true" ]]; then
     fi
     RESULT=$(cat "$OUTFILE")
 elif [[ "$USE_RINTEL" == "true" ]]; then
-    # rintel --schema uses Foundation Models' guided generation, which guarantees
-    # schema-conforming JSON and eliminates the small model's invalid-JSON and
-    # example-parroting failures. The language guardrail still rejects Japanese
-    # prose mixed with <git-data> XML tags, so use a plain delimiter. rintel also
-    # rejects -s values starting with '-' (frontmatter '---'), so pass the system
-    # prompt via the --system= form and -- before the prompt.
+    # rintel --schema uses Foundation Models' guided generation, which constrains
+    # output to the schema and eliminates the small model's invalid-JSON failures
+    # (value-level example-parroting is handled separately below by stripping the
+    # example block). The downstream fence-strip + jq parse still runs as a
+    # backend-agnostic safety net. The language guardrail rejects Japanese prose
+    # mixed with <git-data> XML tags, so use a plain delimiter. rintel rejects
+    # --system values starting with '-' (the frontmatter '---'), so pass it via
+    # the --system= form; '--' then terminates options before the positional prompt.
     RINTEL_PROMPT="以下の git データを分析してコミットメッセージ候補を生成してください。
 
 git データ:

--- a/.config/mise/tasks/auto-commit
+++ b/.config/mise/tasks/auto-commit
@@ -2,23 +2,27 @@
 #MISE description="Generate commit message from staged changes and commit"
 #MISE dir="{{cwd}}"
 #USAGE flag "--codex" help="Use Codex CLI instead of Claude Code"
+#USAGE flag "--rintel" help="Use Apple Intelligence (Foundation Models) via rintel"
 
 set -euo pipefail
 
 DOTFILES="${DOTFILES_PATH:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 USE_CODEX="${usage_codex:-false}"
+USE_RINTEL="${usage_rintel:-false}"
 ABORT_LABEL="--- コミットを中止 ---"
+
+if [[ "$USE_CODEX" == "true" && "$USE_RINTEL" == "true" ]]; then
+    echo "Error: --codex and --rintel are mutually exclusive" >&2
+    exit 1
+fi
 
 if ! command -v jq &>/dev/null; then
     echo "Error: jq command not found. Run 'mise install' to install dependencies." >&2
     exit 1
 fi
 
-if [[ "$USE_CODEX" == "true" ]]; then
-    if ! command -v codex &>/dev/null; then
-        echo "Error: codex command not found" >&2
-        exit 1
-    fi
+# Codex and rintel backends both need a timeout wrapper
+if [[ "$USE_CODEX" == "true" || "$USE_RINTEL" == "true" ]]; then
     if command -v timeout &>/dev/null; then
         TIMEOUT_CMD="timeout"
     elif command -v gtimeout &>/dev/null; then
@@ -27,7 +31,20 @@ if [[ "$USE_CODEX" == "true" ]]; then
         echo "Error: timeout command not found. Run 'brew install coreutils'." >&2
         exit 1
     fi
+fi
+
+if [[ "$USE_CODEX" == "true" ]]; then
+    if ! command -v codex &>/dev/null; then
+        echo "Error: codex command not found" >&2
+        exit 1
+    fi
     SKILL_PATH="${DOTFILES}/.codex/skills/auto-commit/SKILL.md"
+elif [[ "$USE_RINTEL" == "true" ]]; then
+    if ! command -v rintel &>/dev/null; then
+        echo "Error: rintel command not found. Build & install it from the rintel repo: cargo install --path apps/cli" >&2
+        exit 1
+    fi
+    SKILL_PATH="${DOTFILES}/.claude/skills/auto-commit/SKILL.md"
 else
     if ! command -v claude &>/dev/null; then
         echo "Error: claude command not found" >&2
@@ -82,6 +99,62 @@ if [[ "$USE_CODEX" == "true" ]]; then
         exit 1
     fi
     RESULT=$(cat "$OUTFILE")
+elif [[ "$USE_RINTEL" == "true" ]]; then
+    # rintel --schema uses Foundation Models' guided generation, which guarantees
+    # schema-conforming JSON and eliminates the small model's invalid-JSON and
+    # example-parroting failures. The language guardrail still rejects Japanese
+    # prose mixed with <git-data> XML tags, so use a plain delimiter. rintel also
+    # rejects -s values starting with '-' (frontmatter '---'), so pass the system
+    # prompt via the --system= form and -- before the prompt.
+    RINTEL_PROMPT="以下の git データを分析してコミットメッセージ候補を生成してください。
+
+git データ:
+${GIT_DATA}"
+    SCHEMA_FILE=$(mktemp)
+    ERRFILE=$(mktemp)
+    trap 'rm -f "$SCHEMA_FILE" "$ERRFILE"' EXIT
+    cat > "$SCHEMA_FILE" <<'SCHEMA'
+{
+  "type": "object",
+  "required": ["candidates"],
+  "properties": {
+    "candidates": {
+      "type": "array",
+      "description": "2-4 commit message candidates with varied nuance",
+      "minItems": 2,
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": ["message", "description"],
+        "properties": {
+          "message": {"type": "string", "description": "Conventional Commits message: type(scope): description, English, imperative"},
+          "description": {"type": "string", "description": "候補の意図・ニュアンスの違い（日本語）"}
+        }
+      }
+    }
+  }
+}
+SCHEMA
+    # Strip the literal ```json example block from the system prompt: the small
+    # model otherwise copies the example values verbatim (e.g. fix(auth): ...).
+    # The schema and the format/rule prose enforce structure instead.
+    RINTEL_SYSTEM=$(sed '/^```json/,/^```/d' "$SKILL_PATH")
+    RINTEL_OK=false
+    for attempt in 1 2; do
+        if RESULT=$("$TIMEOUT_CMD" -k 5 30 rintel ask \
+            --system="$RINTEL_SYSTEM" \
+            --schema="$SCHEMA_FILE" \
+            -- "$RINTEL_PROMPT" 2>"$ERRFILE"); then
+            RINTEL_OK=true
+            break
+        fi
+        [[ $attempt -lt 2 ]] && echo "rintel ask failed (attempt $attempt/2), retrying..." >&2
+    done
+    if [[ "$RINTEL_OK" != "true" ]]; then
+        echo "Error: rintel ask failed after retries" >&2
+        cat "$ERRFILE" >&2
+        exit 1
+    fi
 else
     RESULT=$(printf '%s' "$PROMPT" | claude -p \
         --model haiku \

--- a/.config/mise/tasks/auto-commit
+++ b/.config/mise/tasks/auto-commit
@@ -138,6 +138,8 @@ SCHEMA
     # Strip the literal ```json example block from the system prompt: the small
     # model otherwise copies the example values verbatim (e.g. fix(auth): ...).
     # The schema and the format/rule prose enforce structure instead.
+    # Assumes SKILL.md contains exactly one ```json block (the example output);
+    # if more are added, narrow this pattern so the system prompt isn't broken.
     RINTEL_SYSTEM=$(sed '/^```json/,/^```/d' "$SKILL_PATH")
     RINTEL_OK=false
     for attempt in 1 2; do

--- a/.config/mise/tasks/suggest-branch
+++ b/.config/mise/tasks/suggest-branch
@@ -41,7 +41,7 @@ if [[ "$USE_CODEX" == "true" ]]; then
     SKILL_PATH="${DOTFILES}/.codex/skills/suggest-branch/SKILL.md"
 elif [[ "$USE_RINTEL" == "true" ]]; then
     if ! command -v rintel &>/dev/null; then
-        echo "Error: rintel command not found. Run 'mise install' to install it." >&2
+        echo "Error: rintel command not found. rintel is mise-managed on macOS arm64 only; on a supported host run 'mise install'." >&2
         exit 1
     fi
     SKILL_PATH="${DOTFILES}/.claude/skills/suggest-branch/SKILL.md"
@@ -106,17 +106,15 @@ elif [[ "$USE_RINTEL" == "true" ]]; then
     # output to the schema and eliminates the small model's invalid-JSON failures
     # (value-level example-parroting is handled separately below by stripping the
     # example block). The downstream fence-strip + jq parse still runs as a
-    # backend-agnostic safety net. The language guardrail rejects Japanese prose
-    # mixed with <git-data> XML tags, so use a plain delimiter. rintel rejects
-    # --system values starting with '-' (the frontmatter '---'), so pass it via
-    # the --system= form; '--' then terminates options before the positional prompt.
-    RINTEL_PROMPT="以下の git データを分析してブランチ名候補を生成してください。
-
-git データ:
-${GIT_DATA}"
+    # backend-agnostic safety net. Git data is passed via --file (a temp file),
+    # not embedded in argv, so large diffs don't hit ARG_MAX and the diff isn't
+    # exposed in the process list. rintel rejects --system values starting with
+    # '-' (the frontmatter '---'), so pass it via the --system= form.
     SCHEMA_FILE=$(mktemp)
+    GITDATA_FILE=$(mktemp)
     ERRFILE=$(mktemp)
-    trap 'rm -f "$SCHEMA_FILE" "$ERRFILE"' EXIT
+    trap 'rm -f "$SCHEMA_FILE" "$GITDATA_FILE" "$ERRFILE"' EXIT
+    printf '%s' "$GIT_DATA" > "$GITDATA_FILE"
     cat > "$SCHEMA_FILE" <<'SCHEMA'
 {
   "type": "object",
@@ -148,7 +146,8 @@ SCHEMA
         if RESULT=$("$TIMEOUT_CMD" -k 5 30 rintel ask \
             --system="$RINTEL_SYSTEM" \
             --schema="$SCHEMA_FILE" \
-            -- "$RINTEL_PROMPT" 2>"$ERRFILE"); then
+            -f "$GITDATA_FILE" \
+            -- "添付ファイルの git データを分析してブランチ名候補を生成してください。" 2>"$ERRFILE"); then
             RINTEL_OK=true
             break
         fi

--- a/.config/mise/tasks/suggest-branch
+++ b/.config/mise/tasks/suggest-branch
@@ -140,6 +140,8 @@ SCHEMA
     # Strip the literal ```json example block from the system prompt: the small
     # model otherwise copies the example values verbatim (e.g. feature/add-user-auth).
     # The schema and the naming-rule prose enforce structure instead.
+    # Assumes SKILL.md contains exactly one ```json block (the example output);
+    # if more are added, narrow this pattern so the system prompt isn't broken.
     RINTEL_SYSTEM=$(sed '/^```json/,/^```/d' "$SKILL_PATH")
     RINTEL_OK=false
     for attempt in 1 2; do

--- a/.config/mise/tasks/suggest-branch
+++ b/.config/mise/tasks/suggest-branch
@@ -41,7 +41,7 @@ if [[ "$USE_CODEX" == "true" ]]; then
     SKILL_PATH="${DOTFILES}/.codex/skills/suggest-branch/SKILL.md"
 elif [[ "$USE_RINTEL" == "true" ]]; then
     if ! command -v rintel &>/dev/null; then
-        echo "Error: rintel command not found. Build & install it from the rintel repo: cargo install --path apps/cli" >&2
+        echo "Error: rintel command not found. Run 'mise install' to install it." >&2
         exit 1
     fi
     SKILL_PATH="${DOTFILES}/.claude/skills/suggest-branch/SKILL.md"
@@ -102,12 +102,14 @@ if [[ "$USE_CODEX" == "true" ]]; then
     fi
     RESULT=$(cat "$OUTFILE")
 elif [[ "$USE_RINTEL" == "true" ]]; then
-    # rintel --schema uses Foundation Models' guided generation, which guarantees
-    # schema-conforming JSON and eliminates the small model's invalid-JSON and
-    # example-parroting failures. The language guardrail still rejects Japanese
-    # prose mixed with <git-data> XML tags, so use a plain delimiter. rintel also
-    # rejects -s values starting with '-' (frontmatter '---'), so pass the system
-    # prompt via the --system= form and -- before the prompt.
+    # rintel --schema uses Foundation Models' guided generation, which constrains
+    # output to the schema and eliminates the small model's invalid-JSON failures
+    # (value-level example-parroting is handled separately below by stripping the
+    # example block). The downstream fence-strip + jq parse still runs as a
+    # backend-agnostic safety net. The language guardrail rejects Japanese prose
+    # mixed with <git-data> XML tags, so use a plain delimiter. rintel rejects
+    # --system values starting with '-' (the frontmatter '---'), so pass it via
+    # the --system= form; '--' then terminates options before the positional prompt.
     RINTEL_PROMPT="以下の git データを分析してブランチ名候補を生成してください。
 
 git データ:

--- a/.config/mise/tasks/suggest-branch
+++ b/.config/mise/tasks/suggest-branch
@@ -3,22 +3,26 @@
 #MISE dir="{{cwd}}"
 #USAGE arg "[base_branch]" help="Base branch to compare against (default: main)"
 #USAGE flag "--codex" help="Use Codex CLI instead of Claude Code"
+#USAGE flag "--rintel" help="Use Apple Intelligence (Foundation Models) via rintel"
 
 set -euo pipefail
 
 DOTFILES="${DOTFILES_PATH:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 USE_CODEX="${usage_codex:-false}"
+USE_RINTEL="${usage_rintel:-false}"
+
+if [[ "$USE_CODEX" == "true" && "$USE_RINTEL" == "true" ]]; then
+    echo "Error: --codex and --rintel are mutually exclusive" >&2
+    exit 1
+fi
 
 if ! command -v jq &>/dev/null; then
     echo "Error: jq command not found. Run 'mise install' to install dependencies." >&2
     exit 1
 fi
 
-if [[ "$USE_CODEX" == "true" ]]; then
-    if ! command -v codex &>/dev/null; then
-        echo "Error: codex command not found" >&2
-        exit 1
-    fi
+# Codex and rintel backends both need a timeout wrapper
+if [[ "$USE_CODEX" == "true" || "$USE_RINTEL" == "true" ]]; then
     if command -v timeout &>/dev/null; then
         TIMEOUT_CMD="timeout"
     elif command -v gtimeout &>/dev/null; then
@@ -27,7 +31,20 @@ if [[ "$USE_CODEX" == "true" ]]; then
         echo "Error: timeout command not found. Run 'brew install coreutils'." >&2
         exit 1
     fi
+fi
+
+if [[ "$USE_CODEX" == "true" ]]; then
+    if ! command -v codex &>/dev/null; then
+        echo "Error: codex command not found" >&2
+        exit 1
+    fi
     SKILL_PATH="${DOTFILES}/.codex/skills/suggest-branch/SKILL.md"
+elif [[ "$USE_RINTEL" == "true" ]]; then
+    if ! command -v rintel &>/dev/null; then
+        echo "Error: rintel command not found. Build & install it from the rintel repo: cargo install --path apps/cli" >&2
+        exit 1
+    fi
+    SKILL_PATH="${DOTFILES}/.claude/skills/suggest-branch/SKILL.md"
 else
     if ! command -v claude &>/dev/null; then
         echo "Error: claude command not found" >&2
@@ -84,6 +101,62 @@ if [[ "$USE_CODEX" == "true" ]]; then
         exit 1
     fi
     RESULT=$(cat "$OUTFILE")
+elif [[ "$USE_RINTEL" == "true" ]]; then
+    # rintel --schema uses Foundation Models' guided generation, which guarantees
+    # schema-conforming JSON and eliminates the small model's invalid-JSON and
+    # example-parroting failures. The language guardrail still rejects Japanese
+    # prose mixed with <git-data> XML tags, so use a plain delimiter. rintel also
+    # rejects -s values starting with '-' (frontmatter '---'), so pass the system
+    # prompt via the --system= form and -- before the prompt.
+    RINTEL_PROMPT="以下の git データを分析してブランチ名候補を生成してください。
+
+git データ:
+${GIT_DATA}"
+    SCHEMA_FILE=$(mktemp)
+    ERRFILE=$(mktemp)
+    trap 'rm -f "$SCHEMA_FILE" "$ERRFILE"' EXIT
+    cat > "$SCHEMA_FILE" <<'SCHEMA'
+{
+  "type": "object",
+  "required": ["candidates"],
+  "properties": {
+    "candidates": {
+      "type": "array",
+      "description": "2-4 branch name candidates",
+      "minItems": 2,
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": {"type": "string", "description": "Branch name in English kebab-case, e.g. feature/add-foo or fix/bar"},
+          "description": {"type": "string", "description": "候補の説明（日本語）"}
+        }
+      }
+    }
+  }
+}
+SCHEMA
+    # Strip the literal ```json example block from the system prompt: the small
+    # model otherwise copies the example values verbatim (e.g. feature/add-user-auth).
+    # The schema and the naming-rule prose enforce structure instead.
+    RINTEL_SYSTEM=$(sed '/^```json/,/^```/d' "$SKILL_PATH")
+    RINTEL_OK=false
+    for attempt in 1 2; do
+        if RESULT=$("$TIMEOUT_CMD" -k 5 30 rintel ask \
+            --system="$RINTEL_SYSTEM" \
+            --schema="$SCHEMA_FILE" \
+            -- "$RINTEL_PROMPT" 2>"$ERRFILE"); then
+            RINTEL_OK=true
+            break
+        fi
+        [[ $attempt -lt 2 ]] && echo "rintel ask failed (attempt $attempt/2), retrying..." >&2
+    done
+    if [[ "$RINTEL_OK" != "true" ]]; then
+        echo "Error: rintel ask failed after retries" >&2
+        cat "$ERRFILE" >&2
+        exit 1
+    fi
 else
     RESULT=$(printf '%s' "$PROMPT" | claude -p \
         --model haiku \


### PR DESCRIPTION
## 変更の概要

mise タスク auto-commit / suggest-branch に、Apple Intelligence (Foundation Models) を使う `--rintel` バックエンドを追加します。既存の Claude (既定) と `--codex` に加え、ローカルのオンデバイス AI で候補生成できるようにします。

## 主な変更点

- 両タスクに `--rintel` フラグを追加します（`--codex` と排他、未導入時は `mise install` を案内）
- rintel CLI を `rintel ask --schema` で呼び出し、guided generation で構造保証された JSON を取得します
- 小型モデル特有の問題に対処します（言語ガードレール回避のためプレーン区切り、`--system=` 形式・`--` 終端、例ブロック除去で値の丸写し抑制）
- rintel を mise の github backend で管理します（`os = ["macos/arm64"]` でゲート）

## 変更の背景

- 機密性の高い差分をローカル完結のオンデバイス AI で処理する選択肢が欲しいためです
- rintel は Apple Silicon + macOS 26 専用のため、非対応環境で `mise install` / `sync-tools` が壊れないよう os 制約を付けています

## 補足

- rintel 本体は別リポジトリで v0.2.0 として公開済みです（`--schema` guided generation 対応、リリースに aarch64 バイナリ添付済み）
- 出力品質は小型オンデバイスモデルの制約が残ります（大きい diff は context 超過で安全停止、Conventional Commits 形式は揺れることあり）。常用は任意のバックエンド扱いです
- レビュー実施済みです（review-router で Must-Fix ゼロ、codex review で指摘ゼロ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コミット候補作成・ブランチ提案・自動コミットで、Apple Intelligence（rintel）バックエンドを選択可能にしました。
* **改善**
  * JSONスキーマ準拠の検証を強化し、最大リトライ回数と失敗時のエラー表示を拡充しました。
* **バグ修正**
  * codex と rintel の同時指定を明確にエラー終了します。対象OSを macOS（arm64）のみに制限しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->