### PR TITLE
RunCat Neo の導入と ccusage カスタムメトリクス連携

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -64,6 +64,7 @@ cask "1password-cli"
 
 # Utilities
 cask "duet"
+mas "RunCat Neo", id: 6757801838 # Menu bar CPU indicator, Mac App Store only (no cask)
 cask "the-unarchiver"
 
 # IME

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ MacOS用の初期セットアップを行います。
 ├── .markdownlint-cli2.jsonc          # markdownlint設定
 ├── renovate.json                     # Renovate依存関係自動更新設定
 ├── launchd/                          # LaunchAgent定義
-│   └── com.rysk.gh-token-env.plist   # GH_TOKENをGUIセッションへ注入
+│   ├── com.rysk.gh-token-env.plist   # GH_TOKENをGUIセッションへ注入
+│   ├── com.rysk.runcat-ccusage.plist # ccusage使用状況を定期採取
+│   └── runcat-ccusage.sh             # RunCat Neoカスタムメトリクス用JSON生成
 └── docs/                             # ドキュメント
     ├── ccmanager.md                  # ccmanager導入ガイド
     ├── claude-code.md                # Claude Code設定詳細
@@ -224,6 +226,17 @@ MacOS用の初期セットアップを行います。
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gh-token-env.plist
     ```
 
+    RunCat Neoのカスタムメトリクス（任意）
+
+    ccusageの使用状況を定期的に `~/.runcat/ccusage.json` へ書き出し、RunCat Neoのメニューバーに表示します。実行間隔は `launchd/com.rysk.runcat-ccusage.plist` の `StartInterval` で定義しています。JSONの更新はスクリプト側の責務で、RunCat Neo自体はファイルを監視するだけです。
+
+    ```bash
+    ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.runcat-ccusage.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.runcat-ccusage.plist
+    ```
+
+    登録後、RunCat Neoの Settings > Metrics > Custom Metrics で「Add Custom Metrics Source」を選びます。ドット始まりのディレクトリはファイル選択ダイアログから辿れないため、`Cmd + Shift + G` で `~/.runcat/ccusage.json` のパスを直接入力します。
+
 4. Docker SSH設定の生成
 
     `build_lambda`関数で使用するDocker用SSH設定を生成します：
@@ -270,7 +283,7 @@ MacOS用の初期セットアップを行います。
 
     このステップを飛ばすと `/auto-commit` `/pr` `/resolve-review` などの Claude Code skill、`mise run auto-commit` / `mise run suggest-branch` (`.claude/skills/{auto-commit,suggest-branch}/collect.sh` を呼ぶ)、Codex の `cloudwatch-logs` (`~/.claude/skills/cloudwatch-logs/cloudwatch_logs.py` を参照) が失敗します。
 
-    第三者がこの dotfiles を fork して利用する場合、`.claude/settings.json` の `permissions.allow` 絶対パス (`/Users/rysk/.claude/skills/...` 形式) を各自の HOME パスに書き換えてください。claude-code#14956 の制約で `~` 展開が効かないため、絶対パス指定が必須です。
+    第三者がこの dotfiles を fork して利用する場合、`.claude/settings.json` の `permissions.allow` 絶対パス (`/Users/rysk/.claude/skills/...` 形式) を各自の HOME パスに書き換えてください。claude-code#14956 の制約で `~` 展開が効かないため、絶対パス指定が必須です。`launchd/` 配下の plist の `ProgramArguments` / `PATH` も同様に絶対パスなので、各自の HOME パスに書き換えてください (launchd は環境変数を展開しません)。
 
 7. Homebrew未提供フォントのインストール
 

--- a/launchd/com.rysk.runcat-ccusage.plist
+++ b/launchd/com.rysk.runcat-ccusage.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  ccusage の使用状況を RunCat Neo カスタムメトリクス JSON (~/.runcat/ccusage.json) へ書き出す。
+  ccusage / jq は mise 管理のため PATH に mise shims を含める。
+
+  StartInterval はこのジョブの実行間隔の唯一の定義 (300 秒)。ccusage は毎回ローカルの
+  JSONL を全走査して数秒かかるため高頻度化は割に合わず、メニューバー表示の鮮度としては
+  5 分で足りるという判断。間隔を変える場合はここだけを直す。
+
+  導入 (symlink の作成手順は README.md を参照):
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.runcat-ccusage.plist
+  解除:
+    launchctl bootout gui/$(id -u)/com.rysk.runcat-ccusage
+    unlink ~/Library/LaunchAgents/com.rysk.runcat-ccusage.plist
+  失敗時のログ: /tmp/com.rysk.runcat-ccusage.err
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rysk.runcat-ccusage</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/rysk/Repositories/rysk/dotfiles/launchd/runcat-ccusage.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/rysk/.local/share/mise/shims:/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/com.rysk.runcat-ccusage.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.rysk.runcat-ccusage.err</string>
+</dict>
+</plist>

--- a/launchd/runcat-ccusage.sh
+++ b/launchd/runcat-ccusage.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ccusage の使用状況を RunCat Neo カスタムメトリクス JSON へ変換する。
+# launchd (com.rysk.runcat-ccusage) が定期実行し ~/.runcat/ccusage.json を更新、
+# RunCat Neo (Settings > Metrics > Custom Metrics) がこのファイルを監視する。
+set -euo pipefail
+
+OUT="${RUNCAT_JSON:-$HOME/.runcat/ccusage.json}"
+mkdir -p "$(dirname "$OUT")"
+
+today="$(date +%Y%m%d)"
+month_start="$(date +%Y%m01)"
+
+# daily / monthly はサブコマンド無しだと Codex 等の他エージェントも合算されるため claude で絞る。
+# blocks (5時間セッションブロック) は Anthropic API 由来の概念で元々 Claude 専用のため、
+# claude blocks と同じ値になる。トップレベルのまま使う。
+daily_json="$(ccusage claude daily --json --since "$today")"
+monthly_json="$(ccusage claude monthly --json --since "$month_start")"
+block_json="$(ccusage blocks --active --json)"
+
+d_cost="$(jq -r '.totals.totalCost // 0' <<<"$daily_json")"
+d_tok="$(jq -r '.totals.totalTokens // 0' <<<"$daily_json")"
+m_cost="$(jq -r '.totals.totalCost // 0' <<<"$monthly_json")"
+
+# ブロック開始直後は projection / burnRate が null になるため、残り時間と経過率は
+# 常に存在する startTime / endTime から自前で求める。burnRate は取れた時だけ使う。
+block="$(jq -c '
+  .blocks[0] // empty
+  | select(.isActive and .costUSD != null)
+  # fromdateiso8601 はミリ秒付き ISO8601 (.000Z) を strptime できないため事前に除去する。
+  | (.startTime | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $start
+  | (.endTime   | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $end
+  | {
+      cost: .costUSD,
+      burn: (.burnRate.costPerHour // null),
+      remaining_min: ((($end - now) / 60) | floor | if . < 0 then 0 else . end),
+      elapsed: (((now - $start) / ($end - $start)) | if . < 0 then 0 elif . > 1 then 1 else . end)
+    }' <<<"$block_json")"
+
+# トークン数を 2.0M / 350K 形式に丸める。
+fmt_tok() {
+  awk -v n="$1" 'BEGIN{
+    if (n >= 1000000)  printf "%.1fM", n/1000000;
+    else if (n >= 1000) printf "%.0fK", n/1000;
+    else                printf "%d", n;
+  }'
+}
+
+metrics="$(jq -n \
+  --arg d_today "$(printf '$%.2f / %s tok' "$d_cost" "$(fmt_tok "$d_tok")")" \
+  --arg d_month "$(printf '$%.2f' "$m_cost")" \
+  '[{title: "今日", formattedValue: $d_today},
+    {title: "今月", formattedValue: $d_month}]')"
+
+# アクティブな5時間ブロックがある時だけ行を足す。バーはブロック経過率。
+if [[ -n "$block" ]]; then
+  b_cost="$(jq -r '.cost' <<<"$block")"
+  b_remaining="$(jq -r '.remaining_min' <<<"$block")"
+  b_burn="$(jq -r '.burn // empty' <<<"$block")"
+  block_row="$(jq -n \
+    --arg v "$(printf '$%.2f (残 %dh%02dm)' "$b_cost" $((b_remaining / 60)) $((b_remaining % 60)))" \
+    --argjson n "$(jq -r '.elapsed' <<<"$block")" \
+    '{title: "ブロック", formattedValue: $v, normalizedValue: $n}')"
+  metrics="$(jq -n --argjson m "$metrics" --argjson b "$block_row" '$m + [$b]')"
+
+  if [[ -n "$b_burn" ]]; then
+    burn_row="$(jq -n --arg v "$(printf '$%.1f/h' "$b_burn")" '{title: "ペース", formattedValue: $v}')"
+    metrics="$(jq -n --argjson m "$metrics" --argjson p "$burn_row" '$m + [$p]')"
+  fi
+fi
+
+# キー名は RunCat Neo の Custom Metrics スキーマで固定。リネームすると無言で描画されなくなる。
+# 書きかけの JSON を RunCat Neo が読まないよう、同一ディレクトリの一時ファイルへ書いて
+# mv で原子的に置換する (公式スキーマドキュメントの Constraints で要求される作法)。
+tmp="$(mktemp "$(dirname "$OUT")/.ccusage.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+jq -n \
+  --arg bar "$(printf '$%.2f' "$d_cost")" \
+  --argjson metrics "$metrics" \
+  --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{
+    title: "Claude Code usage",
+    symbol: "brain.filled.head.profile",
+    metricsBarValue: $bar,
+    metrics: $metrics,
+    lastUpdatedDate: $date
+  }' > "$tmp"
+mv "$tmp" "$OUT"


### PR DESCRIPTION
## 変更の概要

RunCat Neo を Brewfile に追加し、ccusage の使用状況を RunCat Neo のカスタムメトリクスとしてメニューバーに表示するための launchd ジョブを新設します。

## 主な変更点

- Brewfile に `mas "RunCat Neo"` を追加（Homebrew cask が存在せず Mac App Store 専用のため）
- `launchd/runcat-ccusage.sh` を新規作成。`ccusage claude daily` / `ccusage claude monthly` / `ccusage blocks --active` を集計し、今日・今月のコストとアクティブな5時間ブロックの状況を `~/.runcat/ccusage.json` へ RunCat Neo Custom Metrics 形式で書き出します
- `launchd/com.rysk.runcat-ccusage.plist` を新規作成。上記スクリプトを `StartInterval` 300 秒で定期実行する LaunchAgent です
- README のディレクトリツリーと LaunchAgent 導入手順に上記を反映

## 変更の背景

旧 RunCat が Mac App Store から削除され、後継の RunCat Neo がリリースされたため導入します。あわせて RunCat Neo のカスタムメトリクス機能（監視対象 JSON をユーザー側で更新する設計）を使い、Claude Code の使用量を常時可視化します。

## 補足

ローカルでのマルチレビュー（code-reviewer / comment-analyzer / Codex）対応済みです。主な対応は以下です。

- `ccusage daily` / `monthly` はデフォルトで Codex 等の他エージェントも合算するため、`claude` サブコマンドで Claude のみに限定
- ブロック開始直後は `projection` / `burnRate` が null になるため、残り時間と経過率は常に存在する `startTime` / `endTime` から算出（`fromdateiso8601` がミリ秒付き ISO8601 を解釈できない点も対処）
- launchd への登録と RunCat Neo 側のソース登録は実施済みのため、マージ後の追加作業はありません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * RunCat Neo（Mac App Store）をインストール対象に追加しました。
  * Claudeの「今日／今月」のコスト・トークン、アクティブブロックの残り時間と利用ペースを、RunCat Neoのカスタムメトリクスで表示できるようになりました。
  * 定期的に自動更新され、メニューバーから利用状況を把握できます。
* **ドキュメント**
  * LaunchAgentによる設定手順と、パス指定の注意点（絶対パス化など）を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->