### PR TITLE
RunCat NeoにCodexのプラン使用制限を表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ MacOS用の初期セットアップを行います。
 ├── launchd/                          # LaunchAgent定義
 │   ├── com.rysk.gh-token-env.plist   # GH_TOKENをGUIセッションへ注入
 │   ├── com.rysk.runcat-claude-usage.plist # Claudeのプラン使用制限を定期採取
-│   └── runcat-claude-usage.sh        # RunCat Neoカスタムメトリクス用JSON生成
+│   ├── com.rysk.runcat-codex-usage.plist # Codexのプラン使用制限を定期採取
+│   ├── runcat-claude-usage.sh        # Claude用カスタムメトリクスJSON生成
+│   └── runcat-codex-usage.sh         # Codex用カスタムメトリクスJSON生成
 └── docs/                             # ドキュメント
     ├── ccmanager.md                  # ccmanager導入ガイド
     ├── claude-code.md                # Claude Code設定詳細
@@ -228,16 +230,22 @@ MacOS用の初期セットアップを行います。
 
     RunCat Neoのカスタムメトリクス（任意）
 
-    Claudeのプラン使用制限（現在のセッションと週間）を定期的に `~/.runcat/claude-usage.json` へ書き出し、RunCat Neoのメニューバーに表示します。実行間隔は `launchd/com.rysk.runcat-claude-usage.plist` の `StartInterval` で定義しています。JSONの更新はスクリプト側の責務で、RunCat Neo自体はファイルを監視するだけです。
+    ClaudeとCodexのプラン使用制限を定期的に `~/.runcat/claude-usage.json` と `~/.runcat/codex-usage.json` へ書き出し、RunCat Neoのメニューバーに表示します。実行間隔はそれぞれの plist の `StartInterval` で定義しています。JSONの更新はスクリプト側の責務で、RunCat Neo自体はファイルを監視するだけです。
 
-    取得元はClaude Codeの `/usage` コマンドと同じ非公開APIで、認証にはKeychainの `Claude Code-credentials`（Claude Codeのログイン情報）を使います。APIが応答しない場合は直近1時間以内に取得した値を再利用し、それも無い場合はメニューバーが `---` 表示に縮退します。Claude Codeからログアウトした直後も、キャッシュが残っている間は最後に取得した値を表示します。
+    Claude側は現在のセッションと週間の制限を表示します。取得元はClaude Codeの `/usage` コマンドと同じ非公開APIで、認証にはKeychainの `Claude Code-credentials`（Claude Codeのログイン情報）を使います。
+
+    Codex側は週間の制限とモデル別の枠、レートリミットのリセット権の残数を表示します。取得には `codex app-server` のJSON-RPC（`account/rateLimits/read`）を使うため、認証はcodex本体が `~/.codex/auth.json` で解決します。スクリプトはアクセストークンを扱いません。
+
+    どちらも取得に失敗した場合は直近1時間以内に取得した値を再利用し、それも無い場合はメニューバーが `---` 表示に縮退します。ログアウトした直後も、キャッシュが残っている間は最後に取得した値を表示します。
 
     ```bash
     ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.runcat-claude-usage.plist ~/Library/LaunchAgents/
+    ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.runcat-codex-usage.plist ~/Library/LaunchAgents/
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.runcat-claude-usage.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.runcat-codex-usage.plist
     ```
 
-    登録後、RunCat Neoの Settings > Metrics > Custom Metrics で「Add Custom Metrics Source」を選びます。ドット始まりのディレクトリはファイル選択ダイアログから辿れないため、`Cmd + Shift + G` で `~/.runcat/claude-usage.json` のパスを直接入力します。
+    登録後、RunCat Neoの Settings > Metrics > Custom Metrics で「Add Custom Metrics Source」を選びます。ドット始まりのディレクトリはファイル選択ダイアログから辿れないため、`Cmd + Shift + G` で `~/.runcat/claude-usage.json` と `~/.runcat/codex-usage.json` のパスをそれぞれ直接入力します。
 
 4. Docker SSH設定の生成
 

--- a/launchd/com.rysk.runcat-codex-usage.plist
+++ b/launchd/com.rysk.runcat-codex-usage.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Codex のプラン使用制限を RunCat Neo カスタムメトリクス JSON (~/.runcat/codex-usage.json)
+  へ書き出す。codex は Homebrew、jq は mise 管理のため PATH に両方を含める。
+
+  StartInterval はこのジョブの実行間隔の唯一の定義 (300 秒)。codex app-server は照会のたびに
+  OpenAI 側の usage API へ問い合わせるため、短間隔で回すと無駄な負荷になる。5 分は Claude 側の
+  ジョブと揃えた値で、メニューバー表示の鮮度としても足りるという判断。間隔を変える場合はここ
+  だけを直す。
+
+  導入 (symlink の作成手順は README.md を参照):
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.runcat-codex-usage.plist
+  解除:
+    launchctl bootout gui/$(id -u)/com.rysk.runcat-codex-usage
+    unlink ~/Library/LaunchAgents/com.rysk.runcat-codex-usage.plist
+  失敗時のログ: /tmp/com.rysk.runcat-codex-usage.err
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rysk.runcat-codex-usage</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/rysk/Repositories/rysk/dotfiles/launchd/runcat-codex-usage.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/rysk/.local/share/mise/shims:/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/com.rysk.runcat-codex-usage.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.rysk.runcat-codex-usage.err</string>
+</dict>
+</plist>

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -90,21 +90,37 @@ transform_usage() {
   bar="$b"
 }
 
+# app-server を実行時間の上限付きで起動する。上限が要るのは、後続の sleep が閉じるのは stdin
+# だけで、app-server が OpenAI の usage API を待って返さない限りパイプラインが終わらないため。
+# launchd は前回の実行が生きている間 StartInterval の次回分を起動しないので、一度ハングすると
+# 手動で kill するまで表示が固まったままになる。姉妹スクリプトの curl -m 10 と同じ役割。
+# timeout は Brewfile の coreutils 由来。現行 (9.11) は timeout と gtimeout の両方を配置するが、
+# 古い環境では g 付きしか無いことがあるので両対応する。どちらも無ければ上限なしで実行する。
+# ここで諦めると使用率が二度と更新されず、呼び出し側の || true に握り潰されて気付けないため。
+run_app_server() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 15 "$CODEX_BIN" app-server
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 15 "$CODEX_BIN" app-server
+  else
+    "$CODEX_BIN" app-server
+  fi
+}
+
 if command -v "$CODEX_BIN" >/dev/null 2>&1; then
   api_tmp="$(mktemp "$OUT_DIR/.codex-usage-api.XXXXXX")"
-  # initialize と本リクエストを続けて流し込み、sleep で応答を受け取ってから stdin を閉じる。
+  # initialize から本リクエストまでを続けて流し込み、sleep で応答を受け取ってから stdin を閉じる。
   # app-server は stdin の EOF で終了するため、この sleep がプロセスを残さないための仕組みも
   # 兼ねる。応答が 2 秒に間に合わなければ空になり、下のキャッシュ縮退へ落ちる。再試行はしない。
-  # timeout は app-server 側がハングした場合の保険。sleep が閉じるのは stdin だけで、app-server
-  # が OpenAI の usage API を待って返さない限りこのパイプラインは終わらない。launchd は前回の
-  # 実行が生きている間 StartInterval の次回分を起動しないため、一度ハングすると手動で kill する
-  # まで表示が固まったままになる。姉妹スクリプトの curl -m 10 と同じ役割で、通常は 2 秒で終わる
-  # ところに余裕を持たせた値。timeout は Brewfile の coreutils が入れる。
-  { printf '%s\n%s\n' \
+  # initialized は codex 0.144.6 では省いても応答が返るが、プロトコル定義 (ClientNotification の
+  # InitializedNotification) では initialize に続けて送ることになっている。将来のバージョンが
+  # 未送信を拒否しても壊れないよう仕様どおりに送る。
+  { printf '%s\n%s\n%s\n' \
       '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"runcat-codex-usage","title":"RunCat","version":"1.0"}}}' \
+      '{"method":"initialized"}' \
       '{"method":"account/rateLimits/read","id":1,"params":{}}'
     sleep 2
-  } | timeout 15 "$CODEX_BIN" app-server 2>/dev/null \
+  } | run_app_server 2>/dev/null \
     | jq -c 'select(.id == 1) | .result' > "$api_tmp" 2>/dev/null || true
 
   # 実際にメトリクスへ変換できるところまで確認してからキャッシュを置き換える。応答の形を

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -94,7 +94,7 @@ transform_usage() {
 # だけで、app-server が OpenAI の usage API を待って返さない限りパイプラインが終わらないため。
 # launchd は前回の実行が生きている間 StartInterval の次回分を起動しないので、一度ハングすると
 # 手動で kill するまで表示が固まったままになる。姉妹スクリプトの curl -m 10 と同じ役割。
-# timeout は Brewfile の coreutils 由来。現行 (9.11) は timeout と gtimeout の両方を配置するが、
+# timeout は Brewfile の coreutils 由来。現行の 9.11 は timeout と gtimeout の両方を配置するが、
 # 古い環境では g 付きしか無いことがあるので両対応する。どちらも無ければ上限なしで実行する。
 # ここで諦めると使用率が二度と更新されず、呼び出し側の || true に握り潰されて気付けないため。
 run_app_server() {

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -64,6 +64,15 @@ transform_usage() {
           | limit_row(.; window_label(.windowDurationMins)) ),
         ( .rateLimitsByLimitId // {} | to_entries[] | .value
           | select(.limitId != $main and .limitName != null and .primary != null)
+          # 窓が一度も開始していない枠を落とす。未使用の枠は resetsAt が照会のたびに前進して
+          # 常に「今 + 窓長」を返すため、残り時間が窓長とほぼ同じかどうかで判別できる (12 分
+          # 空けて 2 回照会し、メイン枠の resetsAt が固定される一方でモデル別枠が経過時間ぶん
+          # 前進することを実測した)。300 秒の余裕はサーバーとの時計ずれの吸収用で、開始直後の
+          # 枠が数分隠れるが、その時点の値に情報は無い。
+          # これが無いと GPT-5.3-Codex-Spark の枠が 0% のまま並び続ける。この枠は実使用でも
+          # 加算されない不具合が報告されており (https://github.com/openai/codex/issues/23150)、
+          # 未使用なのか集計漏れなのかは区別できないが、どちらでも表示する価値が無い。
+          | select(.primary.resetsAt - now < .primary.windowDurationMins * 60 - 300)
           | limit_row(.primary; "\(window_label(.primary.windowDurationMins)) (\(.limitName))") ),
         ( .rateLimitResetCredits.availableCount
           | select(. != null)

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -41,22 +41,29 @@ bar=""
 transform_usage() {
   local json="$1" m b
   m="$(jq -c '
+    # windowDurationMins と resetsAt はスキーマ上 null を取りうる (RateLimitWindow で必須なのは
+    # usedPercent だけ)。null で算術に入ると jq ごと落ちて、肝心の使用率があるのに全体が ---
+    # へ縮退してしまうので、飾りにあたるこの 2 つは欠けても行を作れるようにしておく。
     def window_label($mins):
       if $mins == 10080 then "週間"
       elif $mins == 300 then "5時間"
+      elif $mins == null then "使用量"
       else "\($mins / 60 | floor)h枠" end;
 
     # resetsAt は epoch 秒。過去になった枠は「残 0」に丸める。
     def left_str($resets):
-      (($resets - now) | if . < 0 then 0 else . end) as $left
-      | if $left >= 86400
-        then "(残 \($left / 86400 | floor)d\(($left % 86400) / 3600 | floor)h)"
-        else "(残 \($left / 3600 | floor)h\((($left % 3600) / 60 | floor) | tostring | if length < 2 then "0" + . else . end)m)"
-        end;
+      if $resets == null then ""
+      else
+        (($resets - now) | if . < 0 then 0 else . end) as $left
+        | if $left >= 86400
+          then " (残 \($left / 86400 | floor)d\(($left % 86400) / 3600 | floor)h)"
+          else " (残 \($left / 3600 | floor)h\((($left % 3600) / 60 | floor) | tostring | if length < 2 then "0" + . else . end)m)"
+          end
+      end;
 
     def limit_row($entry; $title):
       { title: $title,
-        formattedValue: "\($entry.usedPercent)% " + left_str($entry.resetsAt),
+        formattedValue: "\($entry.usedPercent)%" + left_str($entry.resetsAt),
         normalizedValue: ($entry.usedPercent / 100) };
 
     .rateLimits.limitId as $main
@@ -72,7 +79,10 @@ transform_usage() {
           # これが無いと GPT-5.3-Codex-Spark の枠が 0% のまま並び続ける。この枠は実使用でも
           # 加算されない不具合が報告されており (https://github.com/openai/codex/issues/23150)、
           # 未使用なのか集計漏れなのかは区別できないが、どちらでも表示する価値が無い。
-          | select(.primary.resetsAt - now < .primary.windowDurationMins * 60 - 300)
+          # resetsAt か windowDurationMins が null だと開始済みか判定できない。判定できない枠は
+          # 落とさず残す (隠すのは「一度も開始していないと確認できた」枠だけに限る)。
+          | select(.primary.resetsAt == null or .primary.windowDurationMins == null
+                   or (.primary.resetsAt - now < .primary.windowDurationMins * 60 - 300))
           | limit_row(.primary; "\(window_label(.primary.windowDurationMins)) (\(.limitName))") ),
         ( .rateLimitResetCredits.availableCount
           | select(. != null)
@@ -82,8 +92,13 @@ transform_usage() {
     # 応答から 1 行も作れない場合、そのまま採用すると空のカードでキャッシュを潰してしまう。
     | if length == 0 then error("no rate limit entries") else . end' \
     <<<"$json" 2>/dev/null)" || return 1
-  # 数値であることまで確かめる。欠落時に "null%" と表示するより ---  へ縮退した方がよい。
-  b="$(jq -r '.rateLimits.primary.usedPercent | select(type == "number") | "\(.)%"' \
+  # バーの値は行と同じ順で primary → secondary の先頭から採る。primary 固定にすると、
+  # スキーマ上 primary も secondary も null を取りうる (RateLimitSnapshot は required 無しで
+  # どちらも anyOf [RateLimitWindow, null]) ため、secondary だけが返る構成に変わった時に
+  # 行は作れるのにバーだけ失敗して全体が --- へ落ちる。
+  # 数値であることまで確かめるのは、欠落時に "null%" と表示するより --- へ縮退した方がよいため。
+  b="$(jq -r 'first(.rateLimits | (.primary, .secondary) | select(. != null)
+                | .usedPercent | select(type == "number")) | "\(.)%"' \
     <<<"$json" 2>/dev/null)" || return 1
   [[ -n "$m" && -n "$b" ]] || return 1
   metrics="$m"

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -31,12 +31,12 @@ trap 'rm -f "$api_tmp" "$out_tmp"' EXIT
 metrics=""
 bar=""
 
-# rateLimits 応答をメトリクス行とバー文字列へ変換する。フィールド欠落や窓の構成変更で jq は
-# 失敗しうるので、変換できた時だけ metrics/bar を設定し、それ以外は非ゼロを返して呼び出し側の
-# 縮退分岐に委ねる。
-# 行は応答の形から組み立てる。ChatGPT Plus では primary が週間枠のみ (secondary は null) だが、
+# rateLimits 応答をメトリクス行とバー文字列へ変換する。フィールド欠落やウィンドウ構成の変更で
+# jq は失敗しうるので、変換できた時だけ metrics/bar を設定し、それ以外は非ゼロを返して呼び出し
+# 側の縮退分岐に委ねる。
+# 行は応答の形から組み立てる。ChatGPT Plus では primary が週間枠のみで secondary は null だが、
 # プラン変更で 5 時間枠が増えても壊れないよう windowDurationMins からラベルを引く。
-# rateLimitsByLimitId には全体枠 (limitId が rateLimits と同じ) とモデル別枠が混在するので、
+# rateLimitsByLimitId には limitId が rateLimits と同じ全体枠とモデル別枠が混在するので、
 # 全体枠は rateLimits 側と重複するため除外する。
 transform_usage() {
   local json="$1" m b
@@ -64,11 +64,11 @@ transform_usage() {
           | limit_row(.; window_label(.windowDurationMins)) ),
         ( .rateLimitsByLimitId // {} | to_entries[] | .value
           | select(.limitId != $main and .limitName != null and .primary != null)
-          # 窓が一度も開始していない枠を落とす。未使用の枠は resetsAt が照会のたびに前進して
-          # 常に「今 + 窓長」を返すため、残り時間が窓長とほぼ同じかどうかで判別できる (12 分
-          # 空けて 2 回照会し、メイン枠の resetsAt が固定される一方でモデル別枠が経過時間ぶん
-          # 前進することを実測した)。300 秒の余裕はサーバーとの時計ずれの吸収用で、開始直後の
-          # 枠が数分隠れるが、その時点の値に情報は無い。
+          # ウィンドウが一度も開始していない枠を落とす。未使用の枠は resetsAt が照会のたびに
+          # 前進して常に「今 + ウィンドウ長」を返すため、残り時間がウィンドウ長とほぼ同じかで
+          # 判別できる。12 分空けて 2 回照会し、メイン枠の resetsAt が固定される一方でモデル別
+          # 枠が経過時間ぶん前進することを実測した。300 秒の余裕はサーバーとの時計ずれの吸収用
+          # で、開始直後の枠が数分隠れるが、その時点の値に情報は無い。
           # これが無いと GPT-5.3-Codex-Spark の枠が 0% のまま並び続ける。この枠は実使用でも
           # 加算されない不具合が報告されており (https://github.com/openai/codex/issues/23150)、
           # 未使用なのか集計漏れなのかは区別できないが、どちらでも表示する価値が無い。
@@ -94,12 +94,17 @@ if command -v "$CODEX_BIN" >/dev/null 2>&1; then
   api_tmp="$(mktemp "$OUT_DIR/.codex-usage-api.XXXXXX")"
   # initialize と本リクエストを続けて流し込み、sleep で応答を受け取ってから stdin を閉じる。
   # app-server は stdin の EOF で終了するため、この sleep がプロセスを残さないための仕組みも
-  # 兼ねる。応答が 2 秒に間に合わなければ空になり、下のキャッシュ縮退へ落ちる (再試行しない)。
+  # 兼ねる。応答が 2 秒に間に合わなければ空になり、下のキャッシュ縮退へ落ちる。再試行はしない。
+  # timeout は app-server 側がハングした場合の保険。sleep が閉じるのは stdin だけで、app-server
+  # が OpenAI の usage API を待って返さない限りこのパイプラインは終わらない。launchd は前回の
+  # 実行が生きている間 StartInterval の次回分を起動しないため、一度ハングすると手動で kill する
+  # まで表示が固まったままになる。姉妹スクリプトの curl -m 10 と同じ役割で、通常は 2 秒で終わる
+  # ところに余裕を持たせた値。timeout は Brewfile の coreutils が入れる。
   { printf '%s\n%s\n' \
       '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"runcat-codex-usage","title":"RunCat","version":"1.0"}}}' \
       '{"method":"account/rateLimits/read","id":1,"params":{}}'
     sleep 2
-  } | "$CODEX_BIN" app-server 2>/dev/null \
+  } | timeout 15 "$CODEX_BIN" app-server 2>/dev/null \
     | jq -c 'select(.id == 1) | .result' > "$api_tmp" 2>/dev/null || true
 
   # 実際にメトリクスへ変換できるところまで確認してからキャッシュを置き換える。応答の形を

--- a/launchd/runcat-codex-usage.sh
+++ b/launchd/runcat-codex-usage.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Codex のプラン使用制限を RunCat Neo カスタムメトリクス JSON へ変換する。
+# launchd (com.rysk.runcat-codex-usage) が定期実行し ~/.runcat/codex-usage.json を更新、
+# RunCat Neo (Settings > Metrics > Custom Metrics) がこのファイルを監視する。
+#
+# 取得は codex app-server の JSON-RPC (account/rateLimits/read) 経由。認証は codex 本体が
+# ~/.codex/auth.json で解決するため、このスクリプトはアクセストークンを一切扱わない。
+# rollout JSONL を読む案は codex exec 実行分の rate_limits が null になる不具合があり、
+# /api/codex/usage を直接叩く案はトークンの取り回しが必要になるため、どちらも採らない。
+#
+# app-server は experimental 扱いでメソッド名や応答形式が予告なく変わりうる。codex 未導入・
+# 応答形式の変更・サインアウトのいずれでも launchd ジョブを壊さないよう、失敗時は既存
+# キャッシュへ、それも無ければ空メトリクスへ縮退して必ず正常終了する。
+set -euo pipefail
+
+OUT="${RUNCAT_JSON:-$HOME/.runcat/codex-usage.json}"
+OUT_DIR="$(dirname "$OUT")"
+# 縮退動作を検証する時だけ失敗するコマンドに差し替えられるようにしておく。
+CODEX_BIN="${CODEX_BIN:-codex}"
+CACHE="$OUT_DIR/.codex-usage-api.json"
+# codex を使っていない間も直近の消費率を表示し続けるためのキャッシュ。ただし古すぎる値は
+# 「今の消費率」として誤解を招くので上限を設ける。
+CACHE_MAX_AGE=3600
+
+mkdir -p "$OUT_DIR"
+
+api_tmp=""
+out_tmp=""
+trap 'rm -f "$api_tmp" "$out_tmp"' EXIT
+
+metrics=""
+bar=""
+
+# rateLimits 応答をメトリクス行とバー文字列へ変換する。フィールド欠落や窓の構成変更で jq は
+# 失敗しうるので、変換できた時だけ metrics/bar を設定し、それ以外は非ゼロを返して呼び出し側の
+# 縮退分岐に委ねる。
+# 行は応答の形から組み立てる。ChatGPT Plus では primary が週間枠のみ (secondary は null) だが、
+# プラン変更で 5 時間枠が増えても壊れないよう windowDurationMins からラベルを引く。
+# rateLimitsByLimitId には全体枠 (limitId が rateLimits と同じ) とモデル別枠が混在するので、
+# 全体枠は rateLimits 側と重複するため除外する。
+transform_usage() {
+  local json="$1" m b
+  m="$(jq -c '
+    def window_label($mins):
+      if $mins == 10080 then "週間"
+      elif $mins == 300 then "5時間"
+      else "\($mins / 60 | floor)h枠" end;
+
+    # resetsAt は epoch 秒。過去になった枠は「残 0」に丸める。
+    def left_str($resets):
+      (($resets - now) | if . < 0 then 0 else . end) as $left
+      | if $left >= 86400
+        then "(残 \($left / 86400 | floor)d\(($left % 86400) / 3600 | floor)h)"
+        else "(残 \($left / 3600 | floor)h\((($left % 3600) / 60 | floor) | tostring | if length < 2 then "0" + . else . end)m)"
+        end;
+
+    def limit_row($entry; $title):
+      { title: $title,
+        formattedValue: "\($entry.usedPercent)% " + left_str($entry.resetsAt),
+        normalizedValue: ($entry.usedPercent / 100) };
+
+    .rateLimits.limitId as $main
+    | [ ( .rateLimits | (.primary, .secondary) | select(. != null)
+          | limit_row(.; window_label(.windowDurationMins)) ),
+        ( .rateLimitsByLimitId // {} | to_entries[] | .value
+          | select(.limitId != $main and .limitName != null and .primary != null)
+          | limit_row(.primary; "\(window_label(.primary.windowDurationMins)) (\(.limitName))") ),
+        ( .rateLimitResetCredits.availableCount
+          | select(. != null)
+          # 使用率ではなく個数なので、バーを伸ばさないよう normalizedValue は 0 で固定する。
+          | { title: "リセット権", formattedValue: "\(.)", normalizedValue: 0 } )
+      ]
+    # 応答から 1 行も作れない場合、そのまま採用すると空のカードでキャッシュを潰してしまう。
+    | if length == 0 then error("no rate limit entries") else . end' \
+    <<<"$json" 2>/dev/null)" || return 1
+  # 数値であることまで確かめる。欠落時に "null%" と表示するより ---  へ縮退した方がよい。
+  b="$(jq -r '.rateLimits.primary.usedPercent | select(type == "number") | "\(.)%"' \
+    <<<"$json" 2>/dev/null)" || return 1
+  [[ -n "$m" && -n "$b" ]] || return 1
+  metrics="$m"
+  bar="$b"
+}
+
+if command -v "$CODEX_BIN" >/dev/null 2>&1; then
+  api_tmp="$(mktemp "$OUT_DIR/.codex-usage-api.XXXXXX")"
+  # initialize と本リクエストを続けて流し込み、sleep で応答を受け取ってから stdin を閉じる。
+  # app-server は stdin の EOF で終了するため、この sleep がプロセスを残さないための仕組みも
+  # 兼ねる。応答が 2 秒に間に合わなければ空になり、下のキャッシュ縮退へ落ちる (再試行しない)。
+  { printf '%s\n%s\n' \
+      '{"method":"initialize","id":0,"params":{"clientInfo":{"name":"runcat-codex-usage","title":"RunCat","version":"1.0"}}}' \
+      '{"method":"account/rateLimits/read","id":1,"params":{}}'
+    sleep 2
+  } | "$CODEX_BIN" app-server 2>/dev/null \
+    | jq -c 'select(.id == 1) | .result' > "$api_tmp" 2>/dev/null || true
+
+  # 実際にメトリクスへ変換できるところまで確認してからキャッシュを置き換える。応答の形を
+  # 部分的にしか見ずに採用すると、形式が変わった応答で正常なキャッシュを潰してしまい、
+  # 冒頭に書いた「形式変更時は既存キャッシュへ縮退」が働かなくなるため。
+  if transform_usage "$(cat "$api_tmp" 2>/dev/null)"; then
+    mv "$api_tmp" "$CACHE"
+  fi
+fi
+
+# 取得できなかった時だけキャッシュに頼る。存在確認は stat 自体に兼ねさせる。-f で確認して
+# から stat を呼ぶと、その間にキャッシュが消えた場合に stat が空を返し、算術展開が構文エラーに
+# なって set -e で止まってしまう。
+if [[ -z "$metrics" ]]; then
+  cache_mtime="$(stat -f %m "$CACHE" 2>/dev/null || echo 0)"
+  if (( cache_mtime > 0 )) && (( $(date +%s) - cache_mtime <= CACHE_MAX_AGE )); then
+    transform_usage "$(cat "$CACHE" 2>/dev/null)" || true
+  fi
+fi
+
+# 取得もキャッシュ流用もできない、あるいは応答が想定の形でない状態。
+# 空メトリクスにして異常を表示側で気付けるようにする。
+if [[ -z "$metrics" || -z "$bar" ]]; then
+  metrics="[]"
+  bar="---"
+fi
+
+# キー名は RunCat Neo の Custom Metrics スキーマで固定。リネームすると無言で描画されなくなる。
+# 書きかけの JSON を RunCat Neo が読まないよう、同一ディレクトリの一時ファイルへ書いて
+# 公式スキーマドキュメントの Constraints が要求する作法に従い、mv で原子的に置換する。
+out_tmp="$(mktemp "$OUT_DIR/.codex-usage.XXXXXX")"
+if ! jq -n \
+  --arg bar "$bar" \
+  --argjson metrics "$metrics" \
+  --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{
+    title: "Codex usage",
+    symbol: "terminal.fill",
+    metricsBarValue: $bar,
+    metrics: $metrics,
+    lastUpdatedDate: $date
+  }' > "$out_tmp" 2>/dev/null; then
+  # jq が mise のバージョン切り替え等で引けなくなった場合でも表示を止めない。
+  # 埋め込むのはリテラルと date の出力だけなので、jq 無しでもエスケープを気にせず書ける。
+  printf '{"title":"Codex usage","symbol":"terminal.fill","metricsBarValue":"---","metrics":[],"lastUpdatedDate":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$out_tmp"
+fi
+mv "$out_tmp" "$OUT"


### PR DESCRIPTION
## 変更の概要

Codexのプラン使用制限をRunCat Neoのメニューバーへ表示する仕組みを追加します。
既存のClaude用メトリクスはそのまま残し、別のJSONとlaunchdジョブとして並行して動かします。

## 主な変更点

- `launchd/runcat-codex-usage.sh` を追加しました。`codex app-server` のJSON-RPC（`account/rateLimits/read`）から
  使用制限を取得し、RunCat NeoのCustom Metricsスキーマへ変換して `~/.runcat/codex-usage.json` へ書き出します
- `launchd/com.rysk.runcat-codex-usage.plist` を追加しました。Claude側と揃えて5分間隔で実行します
- READMEのRunCat Neoカスタムメトリクス節を、ClaudeとCodexの2ソース構成に改稿しました

## 変更の背景

Claude側は既にプラン使用制限をメニューバーへ表示していますが、Codex側は同じ情報がCLIの中でしか見えませんでした。
`codex app-server` から同等のデータを取得できるため、同じ仕組みで並べて表示できます。

この経路は認証をcodex本体（`~/.codex/auth.json`）に委ねるため、スクリプトがアクセストークンを一切扱いません。
Claude側で必要だったKeychainの読み出しやargv経由の漏洩対策が不要になります。

## 補足

- 取得に失敗した場合は直近1時間のキャッシュへ、それも無ければ `---` 表示へ縮退し、必ず正常終了します
- 応答を実際にメトリクスへ変換できるところまで確認してからキャッシュを置き換えるため、
  形式が変わった応答で正常なキャッシュを潰すことはありません
- モデル別の枠は、ウィンドウが一度も開始していないものを除外しています。
  GPT-5.3-Codex-Sparkの枠が0%のまま並び続けるためで、この枠は実使用でも加算されない不具合が上流で報告されています
- `timeout 15` でapp-server呼び出しに上限を設けています。
  launchdは前回の実行が生きている間は次回分を起動しないため、上限が無いと一度のハングで表示が固まり続けます


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - RunCat NeoのCustom Metricsに、Codexの使用制限（残り枠）とリセット情報を追加（約5分ごとに更新）。
  - 取得失敗時は直近のキャッシュを参照して表示を継続し、失敗しても表示が止まらないように改善しました。
- **ドキュメント**
  - セットアップ手順に、Codex用の書き出し先（JSON）と、Custom Metricsへの登録方法を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->