### PR TITLE
AWS API MCP Server をマネージド AWS MCP Server へ移行

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,14 +8,14 @@
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "aws-api": {
+    "aws-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["awslabs.aws-api-mcp-server@latest"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR",
-        "READ_OPERATIONS_ONLY": "true"
-      }
+      "args": [
+        "mcp-proxy-for-aws@1.6.4",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--read-only"
+      ]
     },
     "playwright": {
       "type": "stdio",

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -12,15 +12,19 @@ AWSドキュメントへのアクセスを提供します。
 - スコープ: プロジェクト
 - 機能: AWS認証不要でドキュメントの閲覧・検索が可能
 
-### AWS API MCP Server
+### AWS MCP Server
 
-AWS CLIコマンドの実行を提供します。
+AWSがホストするマネージドリモートMCPサーバーです。開発終了となったOSS版 `awslabs.aws-api-mcp-server` の後継として移行しました。
 
-- コマンド: `uvx awslabs.aws-api-mcp-server@latest`
+- コマンド: `uvx mcp-proxy-for-aws@1.6.4 https://aws-mcp.us-east-1.api.aws/mcp --read-only`
 - スコープ: プロジェクト
-- 機能: 自然言語からAWS CLIコマンドを生成・実行
-- 設定: `READ_OPERATIONS_ONLY=true`（読み取り専用モード）
-- 前提条件: AWS認証情報の設定（AWS CLI/SDKの設定に従う）
+- 機能: 15,000以上のAWS APIの実行、ドキュメント取得、サンドボックスでのスクリプト実行
+- 構成: ローカルには軽量プロキシ `mcp-proxy-for-aws` のみ配置し、リクエストをSigV4で署名してAWS側で実行
+- 設定: `--read-only` フラグで書き込み権限が必要なツールを無効化。IAMポリシーの `aws:ViaAWSMCPService` コンテキストキーでも制御可能
+- 前提条件: AWS CLI/SDKの認証チェーンに従ったAWS認証情報の設定
+- バージョン: 移行ガイドの推奨に従い、サプライチェーン対策として `@latest` ではなく特定バージョンに固定。更新は Renovate の custom manager が `.mcp.json` とこのドキュメントを追従
+- 運用方針: マルチアカウント環境で IAM ポリシー整備が現実的でないため `--read-only` を維持し、MCP はドキュメント検索等の知識系ツールに限定。読み取りを含む AWS 操作は AWS CLI + プロファイル切替で行う
+- 参考: <https://github.com/awslabs/mcp/blob/main/src/aws-api-mcp-server/MIGRATION.md>
 
 ### Playwright MCP Server
 
@@ -79,14 +83,14 @@ MCPサーバーの設定は以下のファイルに保存されます。
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
     },
-    "aws-api": {
+    "aws-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["awslabs.aws-api-mcp-server@latest"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR",
-        "READ_OPERATIONS_ONLY": "true"
-      }
+      "args": [
+        "mcp-proxy-for-aws@1.6.4",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--read-only"
+      ]
     },
     "playwright": {
       "type": "stdio",

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -18,7 +18,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["github-actions", "mise", "pre-commit"],
+  "enabledManagers": ["github-actions", "mise", "pre-commit", "custom.regex"],
   "labels": ["dependencies"],
   "timezone": "Asia/Tokyo",
   "schedule": ["before 9am on saturday"],
@@ -37,6 +37,16 @@
       "matchDepNames": ["npm:ccusage", "npm:@ccusage/codex"],
       "groupName": "ccusage"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track pinned mcp-proxy-for-aws version in MCP config and docs",
+      "managerFilePatterns": ["/(^|/)\\.mcp\\.json$/", "/^docs/mcp\\.md$/"],
+      "matchStrings": ["mcp-proxy-for-aws@(?<currentValue>\\d+(?:\\.\\d+)+)"],
+      "depNameTemplate": "mcp-proxy-for-aws",
+      "datasourceTemplate": "pypi"
+    }
   ]
 }
 ```
@@ -44,10 +54,11 @@
 各フィールドの説明。
 
 - `extends` - `config:recommended` で推奨プリセットを適用（range更新なし等）。`group:allNonMajor` で minor / patch / digest 更新を 1 PR に集約し、major のみ個別 PR とする（`prHourlyLimit` のデフォルト 2 件/時に小粒な更新が詰まって後回しになるのを防ぐ）
-- `enabledManagers` - 有効にするマネージャを限定。対応しているマネージャは以下の3つ
+- `enabledManagers` - 有効にするマネージャを限定。対応しているマネージャは以下の4つ
   - `github-actions` - `.github/workflows/` 内のアクションバージョン
   - `mise` - `.config/mise/config.toml` のツールバージョン
   - `pre-commit` - `.pre-commit-config.yaml` のフックバージョン
+  - `custom.regex` - 正規表現ベースのカスタムマネージャ（後述の customManagers セクション参照）
 - `labels` - 作成されるPRに付与するラベル
 - `timezone` / `schedule` - 更新チェックのスケジュール
 
@@ -72,6 +83,17 @@
 これにより、ツールのインストールが失敗するバージョンが自動マージされるリスクを防止しています。
 
 パッケージの指定には `matchDepNames` を使用します。以前は `matchPackageNames` が使われていましたが、Renovate v39 以降は `matchDepNames` に統一されています。
+
+### customManagers
+
+専用マネージャが存在しないファイル内のバージョン文字列は、regex カスタムマネージャで追従します。
+
+現在は `mcp-proxy-for-aws`（AWS MCP Server 用プロキシ、詳細は `docs/mcp.md` 参照）を対象に、`.mcp.json` と `docs/mcp.md` 内の `mcp-proxy-for-aws@X.Y.Z` を PyPI データソースで追跡しています。両ファイルが同一 PR で更新されるため、実設定とドキュメントの乖離が起きません。
+
+注意点。
+
+- regex はバージョン文字列の書き換えのみ行う。エンドポイント URL 変更などファイル構造の変更は手動対応
+- `enabledManagers` に `custom.regex` を含めないと customManagers 定義があっても動作しない
 
 ## miseマネージャとの連携
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "group:allNonMajor", "helpers:pinGitHubActionDigests"],
-  "enabledManagers": ["github-actions", "mise", "pre-commit"],
+  "enabledManagers": ["github-actions", "mise", "pre-commit", "custom.regex"],
   "labels": ["dependencies"],
   "timezone": "Asia/Tokyo",
   "schedule": ["before 9am on saturday"],
@@ -30,6 +30,16 @@
     {
       "matchDepNames": ["rysk-tanaka/workflows"],
       "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track pinned mcp-proxy-for-aws version in MCP config and docs",
+      "managerFilePatterns": ["/(^|/)\\.mcp\\.json$/", "/^docs/mcp\\.md$/"],
+      "matchStrings": ["mcp-proxy-for-aws@(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "mcp-proxy-for-aws",
+      "datasourceTemplate": "pypi"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "customType": "regex",
       "description": "Track pinned mcp-proxy-for-aws version in MCP config and docs",
       "managerFilePatterns": ["/(^|/)\\.mcp\\.json$/", "/^docs/mcp\\.md$/"],
-      "matchStrings": ["mcp-proxy-for-aws@(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "matchStrings": ["mcp-proxy-for-aws@(?<currentValue>\\d+(?:\\.\\d+)+)"],
       "depNameTemplate": "mcp-proxy-for-aws",
       "datasourceTemplate": "pypi"
     }


### PR DESCRIPTION
## 変更の概要

開発終了となった OSS 版 `awslabs.aws-api-mcp-server` を、AWS がホストするマネージド AWS MCP Server へ移行します。
あわせて、ピン留めしたプロキシのバージョンを Renovate で自動追従できるようにします。

## 主な変更点

- `.mcp.json` の `aws-api` サーバーを `aws-mcp` に置き換え、`mcp-proxy-for-aws@1.6.4` 経由でマネージドエンドポイントに接続するよう変更します
- 読み取り専用制御を `READ_OPERATIONS_ONLY` 環境変数から `--read-only` フラグに変更します
- Renovate に custom regex manager を追加し、`.mcp.json` と `docs/mcp.md` 内のピン留めバージョンを PyPI データソースで追跡します
- `docs/mcp.md` と `docs/renovate.md` を新構成に合わせて更新します

## 変更の背景

OSS 版 aws-api MCP サーバーが開発終了（end of development）となり、公式の移行ガイドでマネージド版への移行が推奨されているためです。
移行ガイドの推奨に従い、サプライチェーン対策としてプロキシは `@latest` ではなく特定バージョンに固定し、更新は Renovate に委ねます。

## 補足

マルチアカウント環境で IAM ポリシー整備が現実的でないため `--read-only` を維持し、MCP は知識系ツールに限定、AWS 操作は AWS CLI で行う運用方針です。
initialize ハンドシェイクと tools/list の疎通確認済みです。