### PR TITLE
uv キャッシュの定期 prune を導入

### DIFF
--- a/.config/mise/tasks/gc-uv-cache
+++ b/.config/mise/tasks/gc-uv-cache
@@ -21,7 +21,11 @@ cache_bytes() {
         printf '%s' "$out"
         return 0
     fi
-    du -sk "$(uv cache dir 2>/dev/null)" 2>/dev/null | awk '{print $1 * 1024}'
+    # The cache directory does not exist until uv first runs, so `du` can fail here.
+    # Guard the assignment: an unguarded one would abort the whole script via `set -e`
+    # with its stderr already swallowed, which is the opposite of degrading gracefully.
+    out=$(du -sk "$(uv cache dir 2>/dev/null)" 2>/dev/null | awk '{print $1 * 1024}') || out=""
+    printf '%s' "${out:-0}"
 }
 
 human() {
@@ -37,7 +41,7 @@ echo "==> uv cache: $(human "$before")"
 # Fail fast and let the next run pick it up rather than blocking for minutes.
 # `--force` would skip the in-use check and can delete archives a live venv still
 # hardlinks, so it is deliberately not used here.
-holders=$(pgrep -x uv 2>/dev/null | grep -v "^$$\$" || true)
+holders=$(pgrep -x uv 2>/dev/null || true)
 if [ -n "$holders" ]; then
     echo "    in-flight uv processes: $(echo "$holders" | tr '\n' ' ')"
 fi
@@ -48,7 +52,10 @@ rc=$?
 set -e
 
 if [ $rc -ne 0 ]; then
-    if printf '%s' "$output" | grep -q "waiting for lock"; then
+    # uv exposes no distinct exit code for lock contention, so this has to match its
+    # message text. Keep the pattern broad across wordings: a missed match downgrades a
+    # harmless skip into a noisy failure, which is what this whole branch exists to avoid.
+    if printf '%s' "$output" | grep -qiE 'waiting for lock|currently in-use|timeout .*lock'; then
         echo "    skipped: another uv process holds the cache lock (retry on the next run)"
         exit 0
     fi
@@ -60,7 +67,12 @@ printf '%s\n' "$output" | sed 's/^/    /'
 
 after=$(cache_bytes)
 after=${after:-0}
-echo "==> pruned: $(human "$before") -> $(human "$after") (reclaimed $(human $((before - after))))"
+# A concurrent uv run can grow the cache mid-prune, so clamp rather than print "-0.0GiB".
+reclaimed=$((before - after))
+if [ "$reclaimed" -lt 0 ]; then
+    reclaimed=0
+fi
+echo "==> pruned: $(human "$before") -> $(human "$after") (reclaimed $(human "$reclaimed"))"
 
 threshold_bytes=$(awk -v g="$threshold_gib" 'BEGIN { printf "%d", g * 1073741824 }')
 if [ "$after" -gt "$threshold_bytes" ]; then

--- a/.config/mise/tasks/gc-uv-cache
+++ b/.config/mise/tasks/gc-uv-cache
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#MISE description="Prune the uv cache, skipping cleanly while another uv process holds the cache lock"
+#USAGE flag "--threshold <gib>" help="Warn when the cache still exceeds this size (GiB) after pruning" default="20"
+#USAGE flag "--lock-timeout <seconds>" help="Seconds to wait for the uv cache lock before giving up" default="10"
+
+set -euo pipefail
+
+threshold_gib="${usage_threshold:-20}"
+lock_timeout="${usage_lock_timeout:-10}"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "gc-uv-cache: uv not found in PATH" >&2
+    exit 1
+fi
+
+# `uv cache size` is still preview-gated, so fall back to du when the flag or the
+# subcommand disappears in a future release. Both report bytes.
+cache_bytes() {
+    local out
+    if out=$(uv cache size --preview-features cache-size 2>/dev/null) && [[ "$out" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$out"
+        return 0
+    fi
+    du -sk "$(uv cache dir 2>/dev/null)" 2>/dev/null | awk '{print $1 * 1024}'
+}
+
+human() {
+    awk -v b="${1:-0}" 'BEGIN { printf "%.1fGiB", b / 1073741824 }'
+}
+
+before=$(cache_bytes)
+before=${before:-0}
+echo "==> uv cache: $(human "$before")"
+
+# A long-lived `uvx` MCP server holds the cache lock for its whole lifetime, so a
+# scheduled prune collides with any open Claude Code session (astral-sh/uv#16112).
+# Fail fast and let the next run pick it up rather than blocking for minutes.
+# `--force` would skip the in-use check and can delete archives a live venv still
+# hardlinks, so it is deliberately not used here.
+holders=$(pgrep -x uv 2>/dev/null | grep -v "^$$\$" || true)
+if [ -n "$holders" ]; then
+    echo "    in-flight uv processes: $(echo "$holders" | tr '\n' ' ')"
+fi
+
+set +e
+output=$(UV_LOCK_TIMEOUT="$lock_timeout" uv cache prune 2>&1)
+rc=$?
+set -e
+
+if [ $rc -ne 0 ]; then
+    if printf '%s' "$output" | grep -q "waiting for lock"; then
+        echo "    skipped: another uv process holds the cache lock (retry on the next run)"
+        exit 0
+    fi
+    echo "$output" >&2
+    exit $rc
+fi
+
+printf '%s\n' "$output" | sed 's/^/    /'
+
+after=$(cache_bytes)
+after=${after:-0}
+echo "==> pruned: $(human "$before") -> $(human "$after") (reclaimed $(human $((before - after))))"
+
+threshold_bytes=$(awk -v g="$threshold_gib" 'BEGIN { printf "%d", g * 1073741824 }')
+if [ "$after" -gt "$threshold_bytes" ]; then
+    echo "==> still above ${threshold_gib}GiB after pruning." >&2
+    echo "    live .venv hardlinks keep their archive entries alive; check for pinned-version churn," >&2
+    echo "    or escalate manually with: uv cache clean   (full wipe, forces re-download)" >&2
+fi

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "aws-docs": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "args": ["awslabs.aws-documentation-mcp-server@1.1.30"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install Homebrew packages: `brew bundle` (installs packages and fonts defined in `Brewfile`)
 - Install tools: `mise install` (installs all tools defined in `.config/mise/config.toml`)
 - Sync tools after Renovate: `mise run sync-tools` (runs `mise install`, lists prunable versions and prunes them after a `y/N` confirmation, then checks Codex CLI version lag and whether the configured model is still in the catalog; `--yes` skips the prune prompt)
-- Prune uv cache: `mise run gc-uv-cache` (runs `uv cache prune`; exits quietly when a long-lived `uvx` MCP server holds the cache lock, and warns when the cache stays above `--threshold` GiB. Scheduled daily by `launchd/com.rysk.gc-uv-cache.plist` — uv has no TTL, size cap, or automatic GC)
+- Prune uv cache: `mise run gc-uv-cache` (runs `uv cache prune`, skipping quietly while a `uvx` MCP server holds the cache lock; scheduled daily via `launchd/com.rysk.gc-uv-cache.plist` since uv has no automatic GC)
 - Setup WakaTime: `mise run setup-wakatime` (generates `~/.wakatime.cfg` from 1Password)
 - Install fonts: `mise run setup-fonts` or `bash .config/mise/tasks/setup-fonts` (installs Bizin Gothic NF from GitHub Releases)
 - Scan Brewfile: `mise run scan-brew` (shows diff between installed packages and Brewfile)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install Homebrew packages: `brew bundle` (installs packages and fonts defined in `Brewfile`)
 - Install tools: `mise install` (installs all tools defined in `.config/mise/config.toml`)
 - Sync tools after Renovate: `mise run sync-tools` (runs `mise install`, lists prunable versions and prunes them after a `y/N` confirmation, then checks Codex CLI version lag and whether the configured model is still in the catalog; `--yes` skips the prune prompt)
+- Prune uv cache: `mise run gc-uv-cache` (runs `uv cache prune`; exits quietly when a long-lived `uvx` MCP server holds the cache lock, and warns when the cache stays above `--threshold` GiB. Scheduled daily by `launchd/com.rysk.gc-uv-cache.plist` — uv has no TTL, size cap, or automatic GC)
 - Setup WakaTime: `mise run setup-wakatime` (generates `~/.wakatime.cfg` from 1Password)
 - Install fonts: `mise run setup-fonts` or `bash .config/mise/tasks/setup-fonts` (installs Bizin Gothic NF from GitHub Releases)
 - Scan Brewfile: `mise run scan-brew` (shows diff between installed packages and Brewfile)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ MacOS用の初期セットアップを行います。
 ├── .markdownlint-cli2.jsonc          # markdownlint設定
 ├── renovate.json                     # Renovate依存関係自動更新設定
 ├── launchd/                          # LaunchAgent定義
+│   ├── com.rysk.gc-uv-cache.plist    # uvキャッシュを日次でprune
 │   ├── com.rysk.gh-token-env.plist   # GH_TOKENをGUIセッションへ注入
 │   ├── com.rysk.runcat-claude-usage.plist # Claudeのプラン使用制限を定期採取
 │   ├── com.rysk.runcat-codex-usage.plist # Codexのプラン使用制限を定期採取
@@ -226,6 +227,17 @@ MacOS用の初期セットアップを行います。
     ```bash
     ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gh-token-env.plist ~/Library/LaunchAgents/
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gh-token-env.plist
+    ```
+
+    uvキャッシュの定期prune
+
+    `~/.cache/uv` を毎日3時に `uv cache prune` します。uvにはTTLもサイズ上限も自動GCも無く、放置すると際限なく膨らむため定期実行をこちらで用意しています。実体は `mise run gc-uv-cache` と同じスクリプトなので、手動実行もできます。
+
+    週次ではなく日次なのはロック競合を避けるためです。常駐する `uvx` 製のMCPサーバーがキャッシュロックを保持し続けるので、Claude Codeのセッションが開いている間のpruneは必ず失敗します。タスク側はロックを検知すると即座に諦めて正常終了するため、空振りしても害はありません。試行回数を稼いでセッションが閉じている時間帯に当たるのを待ちます。
+
+    ```bash
+    ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gc-uv-cache.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-uv-cache.plist
     ```
 
     RunCat Neoのカスタムメトリクス（任意）

--- a/README.md
+++ b/README.md
@@ -231,9 +231,7 @@ MacOS用の初期セットアップを行います。
 
     uvキャッシュの定期prune
 
-    `~/.cache/uv` を毎日3時に `uv cache prune` します。uvにはTTLもサイズ上限も自動GCも無く、放置すると際限なく膨らむため定期実行をこちらで用意しています。実体は `mise run gc-uv-cache` と同じスクリプトなので、手動実行もできます。
-
-    週次ではなく日次なのはロック競合を避けるためです。常駐する `uvx` 製のMCPサーバーがキャッシュロックを保持し続けるので、Claude Codeのセッションが開いている間のpruneは必ず失敗します。タスク側はロックを検知すると即座に諦めて正常終了するため、空振りしても害はありません。試行回数を稼いでセッションが閉じている時間帯に当たるのを待ちます。
+    uvにはキャッシュの自動GCが無いため、毎日3時に `uv cache prune` を実行します（手動実行は `mise run gc-uv-cache`）。日次スケジュールの理由やロック競合時の挙動は plist 内のコメントを参照してください。
 
     ```bash
     ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gc-uv-cache.plist ~/Library/LaunchAgents/

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -8,7 +8,7 @@ Claude CodeはMCPサーバーを使って外部ツールやサービスと連携
 
 AWSドキュメントへのアクセスを提供します。
 
-- コマンド: `uvx awslabs.aws-documentation-mcp-server@latest`
+- コマンド: `uvx awslabs.aws-documentation-mcp-server@1.1.30`
 - スコープ: プロジェクト
 - 機能: AWS認証不要でドキュメントの閲覧・検索が可能
 
@@ -78,7 +78,7 @@ MCPサーバーの設定は以下のファイルに保存されます。
     "aws-docs": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "args": ["awslabs.aws-documentation-mcp-server@1.1.30"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }

--- a/launchd/com.rysk.gc-uv-cache.plist
+++ b/launchd/com.rysk.gc-uv-cache.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  uv のキャッシュ (~/.cache/uv) を定期的に prune する。uv には TTL もサイズ上限も自動GCも
+  無いため (astral-sh/uv#5731, #9790 はいずれも未実装)、定期実行はこちらで用意する必要がある。
+
+  StartCalendarInterval が実行タイミングの唯一の定義 (毎日 3:00)。週次ではなく日次なのは
+  ロック競合のため。常駐する uvx 製 MCP サーバーがキャッシュロックを保持し続けるので
+  (astral-sh/uv#16112)、Claude Code のセッションが開いている間の prune は必ず失敗する。
+  タスク側はロック検知で即座に諦めて exit 0 するので、空振りは安いし無害。日次で試行回数を
+  稼ぎ、セッションが閉じている時間帯に当たるのを待つ設計。
+
+  スリープ中に発火時刻を跨いだ場合、launchd は起床直後に一度だけ実行する。セッション開始前
+  なのでロックが空いている可能性が高く、この設計とは相性が良い。
+
+  導入 (symlink の作成手順は README.md を参照):
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-uv-cache.plist
+  解除:
+    launchctl bootout gui/$(id -u)/com.rysk.gc-uv-cache
+    unlink ~/Library/LaunchAgents/com.rysk.gc-uv-cache.plist
+  実行ログ: /tmp/com.rysk.gc-uv-cache.out / .err
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rysk.gc-uv-cache</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/rysk/Repositories/rysk/dotfiles/.config/mise/tasks/gc-uv-cache</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/rysk/.local/share/mise/shims:/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/com.rysk.gc-uv-cache.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.rysk.gc-uv-cache.err</string>
+</dict>
+</plist>

--- a/launchd/com.rysk.gc-uv-cache.plist
+++ b/launchd/com.rysk.gc-uv-cache.plist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
-  uv のキャッシュ (~/.cache/uv) を定期的に prune する。uv には TTL もサイズ上限も自動GCも
-  無いため (astral-sh/uv#5731, #9790 はいずれも未実装)、定期実行はこちらで用意する必要がある。
+  uv のキャッシュ (~/.cache/uv) を毎日 3:00 に prune する (実体は mise タスク gc-uv-cache)。
+  uv には TTL もサイズ上限も自動GCも無いため (astral-sh/uv#5731, #9790)、定期実行はこちらで用意する。
 
-  StartCalendarInterval が実行タイミングの唯一の定義 (毎日 3:00)。週次ではなく日次なのは
-  ロック競合のため。常駐する uvx 製 MCP サーバーがキャッシュロックを保持し続けるので
-  (astral-sh/uv#16112)、Claude Code のセッションが開いている間の prune は必ず失敗する。
-  タスク側はロック検知で即座に諦めて exit 0 するので、空振りは安いし無害。日次で試行回数を
-  稼ぎ、セッションが閉じている時間帯に当たるのを待つ設計。
-
-  スリープ中に発火時刻を跨いだ場合、launchd は起床直後に一度だけ実行する。セッション開始前
-  なのでロックが空いている可能性が高く、この設計とは相性が良い。
+  週次ではなく日次なのはロック競合対策。常駐する uvx 製 MCP サーバーがロックを保持し続けるため
+  (astral-sh/uv#16112)、セッションが開いている間の prune は必ず失敗する。タスク側はロック検知で
+  exit 0 するので空振りは無害。日次で試行回数を稼ぎ、セッションが閉じている時間帯に当たるのを待つ。
+  スリープで発火時刻を跨いだ場合、launchd は起床直後に一度だけ実行する。
 
   導入 (symlink の作成手順は README.md を参照):
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-uv-cache.plist

--- a/renovate.json
+++ b/renovate.json
@@ -35,10 +35,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track pinned mcp-proxy-for-aws version in MCP config and docs",
+      "description": "Track pinned PyPI-backed MCP server versions in MCP config and docs. The depName alternation is an explicit allowlist so npm-backed entries (@playwright/mcp, @drawio/mcp) are not matched as PyPI packages.",
       "managerFilePatterns": ["/(^|/)\\.mcp\\.json$/", "/^docs/mcp\\.md$/"],
-      "matchStrings": ["mcp-proxy-for-aws@(?<currentValue>\\d+(?:\\.\\d+)+)"],
-      "depNameTemplate": "mcp-proxy-for-aws",
+      "matchStrings": ["(?<depName>mcp-proxy-for-aws|awslabs\\.aws-documentation-mcp-server)@(?<currentValue>\\d+(?:\\.\\d+)+)"],
       "datasourceTemplate": "pypi"
     }
   ]


### PR DESCRIPTION
## 変更の概要

`~/.cache/uv` が 97.6GiB まで肥大化していたため、`uv cache prune` を毎日実行する仕組みを追加します。
あわせて、蓄積の主要因だった MCP サーバーの `@latest` 指定をバージョン固定に改めます。

## 主な変更点

- `mise run gc-uv-cache` を追加します（ロック競合時は正常終了、prune 後も閾値超過なら警告）
- `launchd/com.rysk.gc-uv-cache.plist` で上記タスクを毎日 3:00 に実行します
- `awslabs.aws-documentation-mcp-server` を `@1.1.30` に固定し、Renovate の追跡対象に加えます

## 変更の背景

uv には TTL・サイズ上限・自動 GC が無く、公式の推奨も「定期的に prune を実行する」のみです。
`uvx <pkg>@latest` は起動のたびに最新版を解決してキャッシュを積むため、発生源の固定と定期削除を組み合わせています。

日次スケジュールなのはロック競合対策です。常駐する `uvx` 製 MCP サーバーがロックを保持し続けるため、
セッション中の prune は失敗します。タスクはロックを検知すると正常終了し、空いている時間帯に当たるのを待ちます。

## 補足

`--force` はロック中でも実行できますが、生きた venv が参照する archive を消しうるため使っていません。
実運用の prune でキャッシュは 97.6GiB から 6.4GiB になりました。
