### PR TITLE
DockerイメージとRust targetの週次GCを導入

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -43,6 +43,7 @@ zoxide = "0.10.0"
 
 # cargo: tools
 "cargo:treemd" = "0.6.0"
+"cargo:cargo-clean-all" = "0.6.4"
 
 # github: tools
 "github:rysk-tanaka/csvr" = "0.2.0"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -42,8 +42,8 @@ zoxide = "0.10.0"
 "aqua:zizmorcore/zizmor" = "1.29.0"
 
 # cargo: tools
-"cargo:treemd" = "0.6.0"
 "cargo:cargo-clean-all" = "0.6.4"
+"cargo:treemd" = "0.6.0"
 
 # github: tools
 "github:rysk-tanaka/csvr" = "0.2.0"

--- a/.config/mise/tasks/gc-docker
+++ b/.config/mise/tasks/gc-docker
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#MISE description="Prune old Docker containers, images, and builder cache, skipping cleanly while OrbStack is stopped"
+#USAGE flag "--until <hours>" help="Remove unused images created more than this many hours ago" default="1440"
+#USAGE flag "--containers-until <hours>" help="Remove stopped containers created more than this many hours ago" default="720"
+
+set -euo pipefail
+
+until_hours="${usage_until:-1440}"
+containers_until="${usage_containers_until:-720}"
+
+if ! command -v orbctl >/dev/null 2>&1; then
+    echo "gc-docker: orbctl not found in PATH" >&2
+    exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+    echo "gc-docker: docker not found in PATH" >&2
+    exit 1
+fi
+
+# Gate on OrbStack state before any docker command: the docker CLI auto-starts
+# the OrbStack VM, and waking it up just to prune defeats the purpose.
+# Exit codes verified on OrbStack 2.2.3: 0=Running, 1=Stopped, 2=Starting.
+# Wrapped in set +e/-e because a bare `orbctl status` would kill the script
+# under `set -e` before the branch below ever runs.
+set +e
+orbctl status >/dev/null 2>&1
+rc=$?
+set -e
+case $rc in
+    0) ;;
+    1 | 2)
+        echo "==> skipped: OrbStack is not running (retry on the next run)"
+        exit 0
+        ;;
+    *)
+        echo "gc-docker: orbctl status failed with exit code $rc" >&2
+        exit 1
+        ;;
+esac
+
+echo "==> docker disk usage (before)"
+docker system df | sed 's/^/    /'
+
+# Containers before images: a stopped container pins its image, so the reverse
+# order leaves those images behind for another cycle. The `until` filter is
+# creation-time based for both (Docker records no last-used time), so a
+# long-running container stopped yesterday is still pruned once its creation is
+# old enough. Acceptable here: these are throwaway dev containers.
+echo "==> pruning stopped containers older than ${containers_until}h"
+docker container prune --force --filter "until=${containers_until}h" | sed 's/^/    /'
+
+echo "==> pruning unused images older than ${until_hours}h"
+docker image prune --all --force --filter "until=${until_hours}h" | sed 's/^/    /'
+
+# Current Docker CLI resolves `docker builder prune` to the Buildx prune, whose
+# size flag is --max-used-space; the legacy one is --keep-storage. Detect the
+# flag from the same command's --help so detection and execution cannot diverge.
+# --all is deliberately omitted (internal/frontend caches are kept), so 2GB caps
+# only the normally-prunable cache, not the total builder cache size.
+echo "==> pruning builder cache down to 2GB"
+if docker builder prune --help 2>&1 | grep -q -- '--max-used-space'; then
+    docker builder prune --force --max-used-space 2GB | sed 's/^/    /'
+else
+    docker builder prune --force --keep-storage 2GB | sed 's/^/    /'
+fi
+
+echo "==> docker disk usage (after)"
+docker system df | sed 's/^/    /'
+
+# Volumes are never pruned automatically: they can hold DB data. Report only.
+vol_reclaimable=$(docker system df | awk '/^Local Volumes/ {print $(NF - 1), $NF}')
+echo "==> volumes are not pruned (may hold DB data); reclaimable: ${vol_reclaimable:-unknown}"

--- a/.config/mise/tasks/gc-docker
+++ b/.config/mise/tasks/gc-docker
@@ -68,5 +68,7 @@ echo "==> docker disk usage (after)"
 docker system df | sed 's/^/    /'
 
 # Volumes are never pruned automatically: they can hold DB data. Report only.
-vol_reclaimable=$(docker system df | awk '/^Local Volumes/ {print $(NF - 1), $NF}')
+# Guard the assignment: this is a report-only line, and a future format change
+# must not turn a successful prune into an error exit under `set -e`.
+vol_reclaimable=$(docker system df | awk '/^Local Volumes/ {print $(NF - 1), $NF}') || vol_reclaimable=""
 echo "==> volumes are not pruned (may hold DB data); reclaimable: ${vol_reclaimable:-unknown}"

--- a/.config/mise/tasks/gc-rust-targets
+++ b/.config/mise/tasks/gc-rust-targets
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE description="Delete Rust target dirs of projects not built recently, via cargo-clean-all"
+#USAGE flag "--keep-days <days>" help="Keep target dirs of projects built within this many days" default="30"
+#USAGE flag "--dir <path>" help="Root directory to scan for cargo projects (default: ~/Repositories)"
+#USAGE flag "--dry-run" help="List cleanable projects without deleting anything"
+
+set -euo pipefail
+
+keep_days="${usage_keep_days:-30}"
+# Default built from $HOME here rather than in #USAGE: a literal "~/Repositories"
+# coming through a quoted variable never tilde-expands.
+dir="${usage_dir:-$HOME/Repositories}"
+
+if ! command -v cargo-clean-all >/dev/null 2>&1; then
+    echo "gc-rust-targets: cargo-clean-all not found in PATH" >&2
+    exit 1
+fi
+
+args=(--keep-days "$keep_days" --yes)
+if [ "${usage_dry_run:-false}" = "true" ]; then
+    args+=(--dry-run)
+fi
+
+# Deletes whole target dirs (next build is a full rebuild); projects built within
+# --keep-days are skipped entirely, so active incremental caches survive.
+cargo-clean-all "$dir" "${args[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install tools: `mise install` (installs all tools defined in `.config/mise/config.toml`)
 - Sync tools after Renovate: `mise run sync-tools` (runs `mise install`, lists prunable versions and prunes them after a `y/N` confirmation, then checks Codex CLI version lag and whether the configured model is still in the catalog; `--yes` skips the prune prompt)
 - Prune uv cache: `mise run gc-uv-cache` (runs `uv cache prune`, skipping quietly while a `uvx` MCP server holds the cache lock; scheduled daily via `launchd/com.rysk.gc-uv-cache.plist` since uv has no automatic GC)
+- Prune Docker: `mise run gc-docker` (prunes old containers, images, and builder cache via OrbStack, skipping quietly while OrbStack is stopped; scheduled weekly via `launchd/com.rysk.gc-docker.plist`; volumes are never pruned)
+- Prune Rust targets: `mise run gc-rust-targets` (deletes `target/` of projects not built for 30+ days via cargo-clean-all, `--dry-run` to preview; scheduled weekly via `launchd/com.rysk.gc-rust-targets.plist`)
 - Setup WakaTime: `mise run setup-wakatime` (generates `~/.wakatime.cfg` from 1Password)
 - Install fonts: `mise run setup-fonts` or `bash .config/mise/tasks/setup-fonts` (installs Bizin Gothic NF from GitHub Releases)
 - Scan Brewfile: `mise run scan-brew` (shows diff between installed packages and Brewfile)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ MacOS用の初期セットアップを行います。
 ├── .markdownlint-cli2.jsonc          # markdownlint設定
 ├── renovate.json                     # Renovate依存関係自動更新設定
 ├── launchd/                          # LaunchAgent定義
+│   ├── com.rysk.gc-docker.plist      # Dockerの古いイメージ等を週次でprune
+│   ├── com.rysk.gc-rust-targets.plist # 休眠Rustプロジェクトのtargetを週次で削除
 │   ├── com.rysk.gc-uv-cache.plist    # uvキャッシュを日次でprune
 │   ├── com.rysk.gh-token-env.plist   # GH_TOKENをGUIセッションへ注入
 │   ├── com.rysk.runcat-claude-usage.plist # Claudeのプラン使用制限を定期採取
@@ -236,6 +238,17 @@ MacOS用の初期セットアップを行います。
     ```bash
     ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gc-uv-cache.plist ~/Library/LaunchAgents/
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-uv-cache.plist
+    ```
+
+    Docker・Rust targetの定期GC
+
+    Dockerの古いコンテナ・イメージ・builderキャッシュのpruneと、休眠Rustプロジェクトの `target/` 削除を毎週日曜に実行します（手動実行は `mise run gc-docker` / `mise run gc-rust-targets`）。volumeを対象外とした理由などの設計判断は各plist内のコメントを参照してください。
+
+    ```bash
+    ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gc-docker.plist ~/Library/LaunchAgents/
+    ln -sf ~/Repositories/rysk/dotfiles/launchd/com.rysk.gc-rust-targets.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-docker.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-rust-targets.plist
     ```
 
     RunCat Neoのカスタムメトリクス（任意）

--- a/launchd/com.rysk.gc-docker.plist
+++ b/launchd/com.rysk.gc-docker.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Docker (OrbStack) の古いコンテナ・イメージ・builder キャッシュを毎週日曜 3:30 に prune する
+  (実体は mise タスク gc-docker)。uv と違いロック競合が無いため週次で十分。
+
+  タスク側は orbctl status で OrbStack 停止中を検知して exit 0 する (docker CLI は
+  OrbStack VM を自動起動してしまうため、prune のために VM を起こさないガード)。
+  volume は DB データ消失リスクがあるため prune 対象外 (reclaimable の情報表示のみ)。
+  スリープで発火時刻を跨いだ場合、launchd は起床直後に一度だけ実行する。
+
+  PATH の /usr/local/bin は docker CLI (OrbStack の symlink) 用。
+
+  導入 (symlink の作成手順は README.md を参照):
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-docker.plist
+  解除:
+    launchctl bootout gui/$(id -u)/com.rysk.gc-docker
+    unlink ~/Library/LaunchAgents/com.rysk.gc-docker.plist
+  実行ログ: /tmp/com.rysk.gc-docker.out / .err
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rysk.gc-docker</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/rysk/Repositories/rysk/dotfiles/.config/mise/tasks/gc-docker</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/rysk/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/com.rysk.gc-docker.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.rysk.gc-docker.err</string>
+</dict>
+</plist>

--- a/launchd/com.rysk.gc-rust-targets.plist
+++ b/launchd/com.rysk.gc-rust-targets.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  ~/Repositories 配下の休眠 Rust プロジェクトの target/ を毎週日曜 4:00 に削除する
+  (実体は mise タスク gc-rust-targets、cargo-clean-all 使用)。Cargo 1.88+ の自動 GC は
+  ~/.cargo のみで target/ は対象外のため、定期実行はこちらで用意する。
+  uv と違いロック競合が無いため週次で十分。30 日以内にビルドされたプロジェクトは
+  target 全体が保護される。
+  スリープで発火時刻を跨いだ場合、launchd は起床直後に一度だけ実行する。
+
+  導入 (symlink の作成手順は README.md を参照):
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rysk.gc-rust-targets.plist
+  解除:
+    launchctl bootout gui/$(id -u)/com.rysk.gc-rust-targets
+    unlink ~/Library/LaunchAgents/com.rysk.gc-rust-targets.plist
+  実行ログ: /tmp/com.rysk.gc-rust-targets.out / .err
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rysk.gc-rust-targets</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/rysk/Repositories/rysk/dotfiles/.config/mise/tasks/gc-rust-targets</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/rysk/.local/share/mise/shims:/opt/homebrew/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/com.rysk.gc-rust-targets.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.rysk.gc-rust-targets.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## 変更の概要

uv キャッシュの定期 prune（#176）に続き、ストレージ肥大化の残り 2 大要因である Docker（OrbStack）と
Rust の `target/` に週次の自動 GC を導入します。

## 主な変更点

- `gc-docker` タスクを追加し、古いコンテナ・イメージ・builder キャッシュを prune します（volume は対象外）
- `gc-rust-targets` タスクを追加し、30 日以上ビルドされていないプロジェクトの `target/` を cargo-clean-all で削除します
- 両タスクを毎週日曜（3:30 / 4:00）に実行する LaunchAgent を追加します
- cargo-clean-all 0.6.4 を mise 管理に追加します（Renovate で追従されます）

## 変更の背景

Docker イメージは 60 日超の未使用分だけで約 33GB、休眠 Rust プロジェクトの `target/` は約 31GB を占めており、
どちらも上流に自動 GC がありません。
一時的な削除ではなく増え続けない仕組みとして、gc-uv-cache と同じ構成（mise タスク + launchd）を踏襲します。

## 補足

- gc-docker は OrbStack 停止中は exit 0 でスキップします（docker CLI が VM を自動起動するのを防ぐため、orbctl status を先に判定します）
- volume を prune しない理由や `until` フィルタの意味論などの設計判断は、スクリプトと plist 内のコメントに記録しています
